### PR TITLE
PCI: Move to libuser. Implement 64-bit BARs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.0.6"
+source = "git+https://github.com/razican/getset?branch=deref#f237bdcc82d39c08ef8f9c841d028908ca2843d5"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "gif"
 version = "0.10.0"
 source = "git+https://github.com/roblabla/image-gif#94bd7a854490f84be86a0334d271ff233eb49610"
@@ -540,6 +550,7 @@ dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "font-rs 0.1.3 (git+https://github.com/orycterope/font-rs)",
+ "getset 0.0.6 (git+https://github.com/razican/getset?branch=deref)",
  "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked_list_allocator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -569,7 +580,6 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libuser 0.1.0",
- "sunrise-libutils 0.1.0",
 ]
 
 [[package]]
@@ -578,7 +588,6 @@ version = "0.1.0"
 dependencies = [
  "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libuser 0.1.0",
 ]
@@ -741,6 +750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum font-rs 0.1.3 (git+https://github.com/orycterope/font-rs)" = "<none>"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
+"checksum getset 0.0.6 (git+https://github.com/razican/getset?branch=deref)" = "<none>"
 "checksum gif 0.10.0 (git+https://github.com/roblabla/image-gif)" = "<none>"
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"

--- a/ahci/src/main.rs
+++ b/ahci/src/main.rs
@@ -64,7 +64,6 @@ extern crate log;
 #[macro_use]
 extern crate bitfield;
 
-mod pci;
 mod hba;
 mod fis;
 mod disk;
@@ -79,6 +78,8 @@ use spin::Mutex;
 use sunrise_libuser::types::Handle;
 use sunrise_libuser::syscalls;
 use sunrise_libuser::ipc::server::SessionWrapper;
+use sunrise_libuser::pci;
+use sunrise_libuser::pci::{PciHeader, BAR};
 
 /// Array of discovered disk.
 ///
@@ -100,7 +101,20 @@ static DISKS: Mutex<Vec<Arc<Mutex<Disk>>>> = Mutex::new(Vec::new());
 /// 3. Start the event loop.
 fn main() {
     debug!("AHCI driver starting up");
-    let ahci_controllers = pci::get_ahci_controllers();
+    let ahci_controllers = pci::discover()
+        .filter(|device| device.class() == 0x01 && device.subclass() == 0x06 && device.prog_if() == 0x01)
+        .map(|device| {
+            match device.header() {
+                PciHeader::GeneralDevice(header00) => {
+                    match header00.bar(5) {
+                        Some(BAR::Memory(addr, size)) => (*addr, *size),
+                        _ => panic!("PCI device with unexpected BAR 5")
+                    }
+                },
+                _ => panic!("PCI device with unexpected header")
+            }
+        });
+
     debug!("AHCI controllers : {:#x?}", ahci_controllers);
     for (bar5, _) in ahci_controllers {
         DISKS.lock().extend(

--- a/libuser/Cargo.toml
+++ b/libuser/Cargo.toml
@@ -17,6 +17,7 @@ failure = { version = "0.1", default-features = false, features = ["derive"] }
 font-rs = { git = "https://github.com/orycterope/font-rs" }
 log = "0.4"
 lazy_static = "1.3"
+getset = { git = "https://github.com/razican/getset", branch = "deref" }
 
 [dependencies.byteorder]
 default-features = false

--- a/libuser/src/lib.rs
+++ b/libuser/src/lib.rs
@@ -57,6 +57,7 @@ pub mod allocator;
 pub mod terminal;
 pub mod window;
 pub mod zero_box;
+pub mod pci;
 mod crt0;
 mod log_impl;
 

--- a/libuser/src/pci.rs
+++ b/libuser/src/pci.rs
@@ -4,7 +4,8 @@
 
 use sunrise_libutils::io::{Io, Pio};
 use spin::Mutex;
-use alloc::prelude::*;
+use getset::Getters;
+use bit_field::BitField;
 
 /// The CONFIG_ADDRESS I/O location.
 pub const CONFIG_ADDRESS: u16 = 0xCF8;
@@ -12,6 +13,7 @@ pub const CONFIG_ADDRESS: u16 = 0xCF8;
 pub const CONFIG_DATA: u16 = 0xCFC;
 
 /// A struct tying the two pci config ports together.
+#[derive(Debug)]
 struct PciConfigPortsPair {
     /// The address port.
     ///
@@ -49,64 +51,114 @@ const MAX_FUNC: u8 = 15;
 const MAX_REGISTER: u8 = 63;
 
 /// A pci device, addressed by its bus number, slot, and function.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Getters)]
 #[allow(clippy::missing_docs_in_private_items)]
-struct PciDevice {
+pub struct PciDevice {
     /// The device's bus number.
+    #[get = "pub"] #[deref]
     bus: u8,
     /// The device's slot number on its bus.
+    #[get = "pub"] #[deref]
     slot: u8,
     /// The device's function number.
+    #[get = "pub"] #[deref]
     function: u8,
 
     /* [register 0x00] */
-    /// Device id.
+    /// Identifies the particular device. Where valid IDs are allocated by the vendor.
+    #[get = "pub"] #[deref]
     did: u16,
-    /// Vendor id.
+    /// Identifies the manufacturer of the device. Where valid IDs are allocated by PCI-SIG (the list
+    /// is [here]) to ensure uniqueness and 0xFFFF is an invalid value that will be returned on read
+    /// accesses to Configuration Space registers of non-existent devices.
+    ///
+    /// [here]: https://pcisig.com/membership/member-companies
+    #[get = "pub"] #[deref]
     vid: u16,
     /* [register 0x01] */
     /* status + command are volatile */
     /* [register 0x02] */
+    /// Specifies the type of function the device performs.
+    #[get = "pub"] #[deref]
     class: u8,
+    /// Specifies the specific function the device performs.
+    #[get = "pub"] #[deref]
     subclass: u8,
+    /// Specifies a register-level programming interface the device has, if it has any at all.
+    #[get = "pub"] #[deref]
     prog_if: u8,
+    /// Specifies a revision identifier for a particular device. Where valid IDs are allocated by the vendor.
+    #[get = "pub"] #[deref]
     rev_id: u8,
     /* [register 0x03] */
     /* bist is volatile */
     header_type: u8,
+    /// Specifies the latency timer in units of PCI bus clocks.
+    #[get = "pub"] #[deref]
     latency_timer: u8,
+    /// Specifies the system cache line size in 32-bit units. A device can limit the number of
+    /// cacheline sizes it can support, if a unsupported value is written to this field, the device
+    /// will behave as if a value of 0 was written.
+    #[get = "pub"] #[deref]
     cache_line_size: u8,
 
     /// Remaining registers values, based on header type.
+    #[get = "pub"] #[deref]
     header: PciHeader
 }
 
 /// Pci header when Header Type == 0x00 (General device).
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Getters)]
 #[allow(clippy::missing_docs_in_private_items)]
-struct PciHeader00 {
-    bar0: BAR,
-    bar1: BAR,
-    bar2: BAR,
-    bar3: BAR,
-    bar4: BAR,
-    bar5: BAR,
+pub struct GeneralPciHeader {
+    bars: [Option<BAR>; 6],
+    /// Points to the Card Information Structure and is used by devices that share silicon between
+    /// CardBus and PCI.
+    #[get] #[deref]
     cardbus_cis_ptr: u32,
     subsystem_id: u16,
     subsystem_vendor_id: u16,
     expansion_rom_base_address: u32,
+    /// Points to a linked list of new capabilities implemented by the device. Used if bit 4 of the
+    /// status register (Capabilities List bit) is set to 1. The bottom two bits are reserved and
+    /// should be masked before the Pointer is used to access the Configuration Space.
+    #[get] #[deref]
     capabilities_ptr: u8,
+    /// Specifies how often the device needs access to the PCI bus (in 1/4 microsecond units).
+    #[get] #[deref]
     max_latency: u8,
+    /// Specifies the burst period length, in 1/4 microsecond units, that the device needs (assuming
+    /// a 33 MHz clock rate).
+    #[get] #[deref]
     min_grant: u8,
+    /// Specifies which interrupt pin the device uses. Where a value of 0x01 is INTA#, 0x02 is
+    /// INTB#, 0x03 is INTC#, 0x04 is INTD#, and 0x00 means the device does not use an interrupt
+    /// pin.
+    #[get] #[deref]
     interrupt_pin: u8,
+    /// Specifies which input of the system interrupt controllers the device's interrupt pin is
+    /// connected to and is implemented by any device that makes use of an interrupt pin. For the
+    /// x86 architecture this register corresponds to the PIC IRQ numbers 0-15 (and not I/O APIC IRQ
+    /// numbers) and a value of 0xFF defines no connection.
+    #[get] #[deref]
     interrupt_line: u8,
+}
+
+impl GeneralPciHeader {
+    /// Get the Base Address Register at the specified index.
+    ///
+    /// May return None if idx bigger than 5, or if specified BAR does not exist (may happen if the
+    /// previous BAR was a 64-bit BAR).
+    pub fn bar(&self, idx: usize) -> Option<&BAR> {
+        self.bars.get(idx).and_then(|x| x.as_ref())
+    }
 }
 
 /// Contents of pci config registers 0x4-0xf, structure varies based on Header Type.
 #[derive(Copy, Clone, Debug)]
-enum PciHeader {
+pub enum PciHeader {
     /// header type == 0x00
-    GeneralDevice(PciHeader00),
+    GeneralDevice(GeneralPciHeader),
     /// header type == 0x01, not implemented
     PCItoPCIBridge,
     /// header type == 0x02, not implemented
@@ -117,9 +169,11 @@ enum PciHeader {
 
 /// Base Address Registers. Minimal implementation, does not support 64-bits BARs.
 #[derive(Copy, Clone, Debug)]
-enum BAR {
+pub enum BAR {
     /// a memory space address and its size
     Memory(u32, u32),
+    /// a 64-bit memory space address and its size
+    Memory64(u64, u64),
     /// an IO space address
     Io(u32, u32)
 }
@@ -161,13 +215,8 @@ impl PciDevice {
             // header_type, but bit 8 informs if device is multi-function, ignore it.
             let header_type = (pci_config_read_word(bus, slot, function, 3) >> 16) as u8;
             return match header_type & 0x7f {
-                0x00 => PciHeader::GeneralDevice(PciHeader00 {
-                    bar0: decode_bar(bus, slot, function, 4),
-                    bar1: decode_bar(bus, slot, function, 5),
-                    bar2: decode_bar(bus, slot, function, 6),
-                    bar3: decode_bar(bus, slot, function, 7),
-                    bar4: decode_bar(bus, slot, function, 8),
-                    bar5: decode_bar(bus, slot, function, 9),
+                0x00 => PciHeader::GeneralDevice(GeneralPciHeader {
+                    bars: decode_bars(bus, slot, function),
                     cardbus_cis_ptr: pci_config_read_word(bus, slot, function, 0xa),
                     subsystem_id:        (pci_config_read_word(bus, slot, function, 0xb) >> 16) as u16,
                     subsystem_vendor_id:  pci_config_read_word(bus, slot, function, 0xb) as u16,
@@ -183,9 +232,8 @@ impl PciDevice {
                 other => PciHeader::UnknownHeaderType(other)
             };
 
-            /// Decode an u32 to BAR.
-            /// 64-bit BARs are not supported.
-            fn decode_bar(bus: u8, slot: u8, function: u8, register: u8) -> BAR {
+            /// Decode an u32 to .
+            fn decode_bar(bus: u8, slot: u8, function: u8, register: u8) -> (u32, u32) {
                 // read bar address
                 let addr = pci_config_read_word(bus, slot, function, register);
                 // write to get length
@@ -194,16 +242,40 @@ impl PciDevice {
                 let length = pci_config_read_word(bus, slot, function, register);
                 // restore original value
                 pci_config_write_word(bus, slot, function, register, addr);
-                match addr & 0x01 {
-                    0 => {
-                        // memory space bar
-                        BAR::Memory(addr & 0xFFFF_FFF0, (!(length & 0xFFFF_FFF0)).wrapping_add(1))
-                    },
-                    _ => {
-                        // io space bar
-                        BAR::Io(addr & 0xFFFF_FFFC, (!(length & 0xFFFF_FFFC)).wrapping_add(1))
-                    }
+
+                (addr, length)
+            }
+
+            fn decode_bars(bus: u8, slot: u8, function: u8) -> [Option<BAR>; 6] {
+                let mut register = 4;
+                let mut bars = [None; 6];
+                while register < 10 {
+                    let (addr, length) = decode_bar(bus, slot, function, register);
+                    bars[register as usize - 4] = match (addr.get_bit(0), addr.get_bits(1..3)) {
+                        (false, 0) => {
+                            // memory space bar
+                            Some(BAR::Memory(addr & 0xFFFF_FFF0, (!(length & 0xFFFF_FFF0)).wrapping_add(1)))
+                        },
+                        (false, 2) => {
+                            // memory space bar
+                            register += 1;
+                            let (addrhigh, lengthhigh) = decode_bar(bus, slot, function, register);
+                            let addr = (addr as u64 & 0xFFFF_FFF0) | ((addrhigh as u64) << 32);
+                            let length = ((length as u64 & 0xFFFF_FFF0) | ((lengthhigh as u64) << 32)).wrapping_add(1);
+                            Some(BAR::Memory64(addr, length))
+                        },
+                        (true, _) => {
+                            // io space bar
+                            Some(BAR::Io(addr & 0xFFFF_FFFC, (!(length & 0xFFFF_FFFC)).wrapping_add(1)))
+                        },
+                        _ => {
+                            info!("Unsupported PCI BAR idx {} value {:#08x}", register - 4, addr);
+                            None
+                        }
+                    };
+                    register += 1;
                 }
+                bars
             }
         }
     }
@@ -279,51 +351,50 @@ fn pci_config_write_word(bus: u8, slot: u8, func: u8, register: u8, value: u32) 
     ports.data.write(value)
 }
 
+/// Iterator created with the [discover] function.
+// First u8 is bus, second is slot, third is func.
+#[derive(Debug)]
+struct PciDeviceIterator(u8, u8, u8);
+
+impl Iterator for PciDeviceIterator {
+    type Item = PciDevice;
+    fn next(&mut self) -> Option<PciDevice> {
+        for bus in self.0..MAX_BUS {
+            for slot in self.1..MAX_SLOT {
+                // test function 0.
+                if let Some(device) = PciDevice::probe(bus, slot, 0) {
+                    let is_multifunction = device.header_type & 0x80 != 0;
+                    if self.2 == 0 {
+                        self.2 += 1;
+                        return Some(device);
+                    }
+                    // check for other function on the same device
+                    if is_multifunction {
+                        for function in self.2..MAX_FUNC {
+                            self.2 += 1;
+                            if let Some(device) = PciDevice::probe(bus, slot, function) {
+                                return Some(device);
+                            }
+                        }
+                    }
+                }
+                self.2 = 0;
+                self.1 += 1;
+            }
+            self.2 = 0;
+            self.1 = 0;
+            self.0 += 1;
+        }
+        return None;
+    }
+}
+
 /// Discover all pci devices, by probing the PID-VID of every slot on every bus.
 ///
 /// A device is discovered when its `(bus, slot, function 0x00)[register 0x00] != 0xFFFF_FFFF`.
 /// Then, an additional [PciDevice] will be returned for every of its other functions that also
 /// return anything different from `0xFFFF_FFFF`.
-fn discover() -> Vec<PciDevice> {
-    let mut devices = vec![];
-    for bus in 0..MAX_BUS {
-        for slot in 0..MAX_SLOT {
-            // test function 0.
-            if let Some(device) = PciDevice::probe(bus, slot, 0) {
-                let is_multifunction = device.header_type & 0x80 != 0;
-                devices.push(device);
-                // check for other function on the same device
-                if is_multifunction {
-                    for function in 1..MAX_FUNC {
-                        if let Some(device) = PciDevice::probe(bus, slot, function) {
-                            devices.push(device);
-                        }
-                    }
-                }
-            }
-        }
-    }
-    devices
+pub fn discover() -> impl Iterator<Item = PciDevice> + core::fmt::Debug {
+    PciDeviceIterator(0, 0, 0)
 }
 
-/// Gets the ahci controllers found by pci discovery.
-///
-/// # Returns
-///
-/// Returns the controller's BAR5 address and size, if one was found.
-pub fn get_ahci_controllers() -> Vec<(u32, u32)> {
-    discover().iter()
-        .filter(|device| device.class == 0x01 && device.subclass == 0x06 && device.prog_if == 0x01)
-        .map(|device| {
-            match device.header {
-                PciHeader::GeneralDevice(header00) => {
-                    match header00.bar5 {
-                        BAR::Memory(addr, size) => (addr, size),
-                        _ => panic!("PCI device with unexpected BAR 5")
-                    }
-                },
-                _ => panic!("PCI device with unexpected header")
-            }
-        })
-        .collect()
-}


### PR DESCRIPTION
Share the PCI implementation across multiple drivers by moving it to libuser. Should eventually move to its own service, but this is a good temporary measure.