### PR TITLE
Better logging - more colors, less duplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,7 @@ dependencies = [
 name = "sunrise-clock"
 version = "0.1.0"
 dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libuser 0.1.0",
 ]
 

--- a/clock/Cargo.toml
+++ b/clock/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 
 [dependencies]
 sunrise-libuser = { path = "../libuser" }
+log = "0.4.6"

--- a/clock/src/main.rs
+++ b/clock/src/main.rs
@@ -19,8 +19,6 @@
 #[macro_use]
 extern crate sunrise_libuser;
 #[macro_use]
-extern crate alloc;
-#[macro_use]
 extern crate log;
 
 use sunrise_libuser::terminal::{Terminal, WindowSize};
@@ -156,7 +154,7 @@ fn main() {
                 year = (year & 0x0F) + ((year / 16) * 10);
             }
 
-            let _ = info!("{:02}:{:02}:{:02} {} {:02} {} {}", hours, minutes, seconds, get_day_of_week(dayofweek), day, get_month(month), year);
+            info!("{:02}:{:02}:{:02} {} {:02} {} {}", hours, minutes, seconds, get_day_of_week(dayofweek), day, get_month(month), year);
             let _ = write!(&mut logger, "\n{:02}:{:02}:{:02} {} {:02} {} {}", hours, minutes, seconds, get_day_of_week(dayofweek), day, get_month(month), year);
         }
     }

--- a/clock/src/main.rs
+++ b/clock/src/main.rs
@@ -20,6 +20,8 @@
 extern crate sunrise_libuser;
 #[macro_use]
 extern crate alloc;
+#[macro_use]
+extern crate log;
 
 use sunrise_libuser::terminal::{Terminal, WindowSize};
 use sunrise_libuser::io::{self, Io};
@@ -154,7 +156,7 @@ fn main() {
                 year = (year & 0x0F) + ((year / 16) * 10);
             }
 
-            let _ = syscalls::output_debug_string(&format!("{:02}:{:02}:{:02} {} {:02} {} {}", hours, minutes, seconds, get_day_of_week(dayofweek), day, get_month(month), year));
+            let _ = info!("{:02}:{:02}:{:02} {} {:02} {} {}", hours, minutes, seconds, get_day_of_week(dayofweek), day, get_month(month), year);
             let _ = write!(&mut logger, "\n{:02}:{:02}:{:02} {} {:02} {} {}", hours, minutes, seconds, get_day_of_week(dayofweek), day, get_month(month), year);
         }
     }

--- a/kernel/src/log_impl/mod.rs
+++ b/kernel/src/log_impl/mod.rs
@@ -20,11 +20,19 @@ impl Log for Logger {
     }
 
     fn log(&self, record: &Record<'_>) {
+        use crate::devices::rs232::{SerialAttributes, SerialColor};
+        let color = SerialAttributes::fg(match record.level() {
+            log::Level::Error => SerialColor::Red,
+            log::Level::Warn  => SerialColor::Yellow,
+            log::Level::Info  => SerialColor::Green,
+            log::Level::Debug => SerialColor::Cyan,
+            log::Level::Trace => SerialColor::White,
+        });
         if self.filter.read().matches(record) {
             if let Some(thread) = scheduler::try_get_current_thread() {
-                writeln!(SerialLogger, "[{}] - {} - {} - {}", record.level(), record.target(), thread.process.name, record.args());
+                writeln!(SerialLogger, "[{}{}{}] - {} - {} - {}", color, record.level(), SerialAttributes::default(), record.target(), thread.process.name, record.args());
             } else {
-                writeln!(SerialLogger, "[{}] - {} - {}", record.level(), record.target(), record.args());
+                writeln!(SerialLogger, "[{}{}{}] - {} - {}", color, record.level(), SerialAttributes::default(), record.target(), record.args());
             }
         }
     }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -6,7 +6,7 @@
 //! Currently doesn't do much, besides booting and printing Hello World on the
 //! screen. But hey, that's a start.
 
-#![feature(lang_items, start, asm, global_asm, compiler_builtins_lib, naked_functions, core_intrinsics, const_fn, abi_x86_interrupt, allocator_api, box_syntax, no_more_cas, const_vec_new, step_trait, thread_local, nll, underscore_const_names, doc_cfg)]
+#![feature(lang_items, start, asm, global_asm, compiler_builtins_lib, naked_functions, core_intrinsics, const_fn, abi_x86_interrupt, allocator_api, box_syntax, no_more_cas, const_vec_new, step_trait, thread_local, nll, underscore_const_names, doc_cfg, exclusive_range_pattern)]
 #![no_std]
 #![cfg_attr(target_os = "none", no_main)]
 #![recursion_limit = "1024"]

--- a/libuser/src/ipc/macros.rs
+++ b/libuser/src/ipc/macros.rs
@@ -206,7 +206,7 @@ macro_rules! object {
         match $cmdid {
             $($fcmdid => $fcmd,)*
             cmd => {
-                let _ = $crate::syscalls::output_debug_string(&format!("Unknown cmdid: {}", cmd));
+                let _ = $crate::__log::warn!("Unknown cmdid: {}", cmd);
                 Err($crate::error::KernelError::PortRemoteDead.into())
             }
         }

--- a/libuser/src/ipc/server.rs
+++ b/libuser/src/ipc/server.rs
@@ -102,7 +102,7 @@ impl WaitableManager {
                 Ok(false) => (),
                 Ok(true) => { waitables.remove(idx); },
                 Err(err) => {
-                    let _ = error!("Error: {}", err);
+                    error!("Error: {}", err);
                     waitables.remove(idx);
                 }
             }

--- a/libuser/src/ipc/server.rs
+++ b/libuser/src/ipc/server.rs
@@ -102,7 +102,7 @@ impl WaitableManager {
                 Ok(false) => (),
                 Ok(true) => { waitables.remove(idx); },
                 Err(err) => {
-                    let _ = syscalls::output_debug_string(&format!("Error: {}", err));
+                    let _ = error!("Error: {}", err);
                     waitables.remove(idx);
                 }
             }

--- a/libuser/src/lib.rs
+++ b/libuser/src/lib.rs
@@ -36,9 +36,6 @@ extern crate failure;
 #[doc(hidden)]
 pub extern crate log as __log;
 
-#[macro_use]
-extern crate lazy_static;
-
 use swipc_gen::gen_ipc;
 
 pub mod caps;

--- a/libuser/src/lib.rs
+++ b/libuser/src/lib.rs
@@ -31,9 +31,11 @@ extern crate sunrise_libutils;
 #[macro_use]
 extern crate failure;
 
-
+// Marked public for use in the object macro.
 #[macro_use]
-extern crate log;
+#[doc(hidden)]
+pub extern crate log as __log;
+
 #[macro_use]
 extern crate lazy_static;
 
@@ -87,7 +89,7 @@ static ALLOCATOR: allocator::Allocator = allocator::Allocator::new();
 #[cfg(any(all(target_os = "none", not(test)), rustdoc))]
 #[panic_handler] #[no_mangle]
 pub extern fn panic_fmt(p: &core::panic::PanicInfo<'_>) -> ! {
-    let _ = syscalls::output_debug_string(&format!("{}", p));
+    let _ = syscalls::output_debug_string(&format!("{}", p), 10, "sunrise_libuser::panic_fmt");
     syscalls::exit_process();
 }
 

--- a/libuser/src/log_impl.rs
+++ b/libuser/src/log_impl.rs
@@ -3,21 +3,13 @@
 //! Redirects all logs to the kernel logger (output_debug_string syscall). No
 //! filtering is done, so everything will be sent.
 
-use spin::Mutex;
-use arrayvec::ArrayString;
 use log::{self, Log, LevelFilter, Metadata, Record};
 use crate::syscalls::output_debug_string;
-use core::fmt::{self, Write};
 
 /// Log implementation structure.
 ///
 /// See module documentation for more information.
 struct Logger;
-
-struct LogItem<'a> {
-    cur_level: u64,
-    cur_target: &'a str,
-}
 
 impl Log for Logger {
     fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
@@ -32,7 +24,7 @@ impl Log for Logger {
             log::Level::Debug => 70,
             log::Level::Trace => 90,
         };
-        output_debug_string(&*format!("{}", record.args()), level, record.target());
+        let _ = output_debug_string(&*format!("{}", record.args()), level, record.target());
     }
 
     fn flush(&self) {}

--- a/libuser/src/log_impl.rs
+++ b/libuser/src/log_impl.rs
@@ -9,18 +9,15 @@ use log::{self, Log, LevelFilter, Metadata, Record};
 use crate::syscalls::output_debug_string;
 use core::fmt::{self, Write};
 
-lazy_static! {
-    /// Buffer where pending writes are stored. The buffer is only flushed when
-    /// a \n is written, or when it's full.
-    ///
-    /// In practice, every log will cause a single line (at least) to be written.
-    static ref SVC_LOG_BUFFER: Mutex<ArrayString<[u8; 256]>> = Mutex::new(ArrayString::new());
-}
-
 /// Log implementation structure.
 ///
 /// See module documentation for more information.
 struct Logger;
+
+struct LogItem<'a> {
+    cur_level: u64,
+    cur_target: &'a str,
+}
 
 impl Log for Logger {
     fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
@@ -28,30 +25,17 @@ impl Log for Logger {
     }
 
     fn log(&self, record: &Record<'_>) {
-        let _ = writeln!(Logger, "[{}] - {} - {}", record.level(), record.target(), record.args());
+        let level = match record.level() {
+            log::Level::Error => 10,
+            log::Level::Warn => 30,
+            log::Level::Info => 50,
+            log::Level::Debug => 70,
+            log::Level::Trace => 90,
+        };
+        output_debug_string(&*format!("{}", record.args()), level, record.target());
     }
 
     fn flush(&self) {}
-}
-
-impl fmt::Write for Logger {
-    fn write_str(&mut self, data: &str) -> fmt::Result {
-        let mut svc_log_buffer = SVC_LOG_BUFFER.lock();
-        if let Ok(()) = svc_log_buffer.try_push_str(data) {
-            if let Some(pos) = svc_log_buffer.rfind('\n') {
-                let _ = output_debug_string(&svc_log_buffer.as_str()[..pos]);
-                *svc_log_buffer = ArrayString::from(&svc_log_buffer[pos + 1..]).unwrap();
-            }
-        } else {
-            // Worse-case. Just print it all out and start fresh.
-            if !svc_log_buffer.is_empty() {
-                let _ = output_debug_string(svc_log_buffer.as_str());
-            }
-            let _ = output_debug_string(data);
-            svc_log_buffer.clear();
-        }
-        Ok(())
-    }
 }
 
 /// Initializes the global logger with the svc logger.

--- a/libuser/src/syscalls.rs
+++ b/libuser/src/syscalls.rs
@@ -137,7 +137,7 @@ pub fn exit_process() -> ! {
     unsafe {
         match syscall(nr::ExitProcess, 0, 0, 0, 0, 0, 0) {
             Ok(_) => (),
-            Err(err) => { let _ = output_debug_string(&format!("Failed to exit: {}", err)); },
+            Err(err) => { let _ = output_debug_string(&format!("Failed to exit: {}", err), 10, "sunrise_libuser::syscalls::exit_process"); },
         }
         #[allow(clippy::empty_loop)]
         loop {} // unreachable, but we can't panic, as panic! calls exit_process
@@ -303,9 +303,9 @@ pub fn send_sync_request_with_user_buffer(buf: &mut [u8], handle: &ClientSession
 /// Print the given string to the kernel's debug output.
 ///
 /// Currently, this prints the string to the serial port.
-pub fn output_debug_string(s: &str) -> Result<(), KernelError> {
+pub fn output_debug_string(s: &str, level: usize, target: &str) -> Result<(), KernelError> {
     unsafe {
-        syscall(nr::OutputDebugString, s.as_ptr() as _, s.len(), 0, 0, 0, 0)?;
+        syscall(nr::OutputDebugString, s.as_ptr() as _, s.len(), level, target.as_ptr() as _, target.len(), 0)?;
         Ok(())
     }
 }

--- a/sm/src/main.rs
+++ b/sm/src/main.rs
@@ -37,7 +37,6 @@
 
 #[macro_use]
 extern crate sunrise_libuser as libuser;
-#[macro_use]
 extern crate alloc;
 
 

--- a/vi/src/main.rs
+++ b/vi/src/main.rs
@@ -22,7 +22,6 @@
 #[macro_use]
 extern crate sunrise_libuser as libuser;
 
-#[macro_use]
 extern crate alloc;
 
 


### PR DESCRIPTION
Brings three improvements:

- Puts some color on the log level, which is neat
- Allows filtering of logs coming from userspace applications in grub. We can now do `sunrise_clock=debug,info` to get more debug information from sunrise_clock, for instance.
- Makes the outputDebugString aware of the log formatting, which results in logs that look like the following:



```
[INFO] - sunrise_clock - clock - 13:59:48 Thursday 23 May 19
```

instead of the old:

```
[INFO] - sunrise_kernel::interrupts::syscalls - clock - [INFO] - sunrise_clock - 13:59:48 Thursday 23 May 19
```