### PR TITLE
 Properly implement A/B/W buffers

### DIFF
--- a/kernel/src/ipc/session.rs
+++ b/kernel/src/ipc/session.rs
@@ -298,7 +298,7 @@ fn buf_map(from_buf: &[u8], to_buf: &mut [u8], curoff: &mut usize, from_mem: &mu
             };
 
         let mut size_handled = 0;
-        if addr % PAGE_SIZE != 0 {
+        if addr % PAGE_SIZE != 0 || size < PAGE_SIZE {
             // memcpy the first page.
             let first_page_size = core::cmp::min(PAGE_SIZE - (addr % PAGE_SIZE), size);
 
@@ -409,7 +409,7 @@ fn buf_unmap(buffer: &Buffer, from_mem: &mut ProcessMemory, to_mem: &mut Process
 
     let mut result: Result<(), UserspaceError> = Ok(());
 
-    if addr.addr() % PAGE_SIZE != 0 {
+    if addr.addr() % PAGE_SIZE != 0 || size < PAGE_SIZE {
         let first_page_size = core::cmp::min(PAGE_SIZE - (addr.addr() % PAGE_SIZE), size);
 
         if buffer.writable {

--- a/kernel/src/ipc/session.rs
+++ b/kernel/src/ipc/session.rs
@@ -283,15 +283,15 @@ fn buf_map(from_buf: &[u8], to_buf: &mut [u8], curoff: &mut usize, from_mem: &mu
         let mut mapping_error_handling_logic =
             |to_mem: &mut ProcessMemory, error: KernelError, mut first_page_info_opt: Option<(VirtualAddress, usize)>, mut middle_page_info_opt: Option<(VirtualAddress, usize)>, mut last_page_info_opt: Option<(VirtualAddress, usize)>| {
                 if let Some(first_page_info) = first_page_info_opt.take() {
-                    to_mem.unmap(first_page_info.0, first_page_info.1);
+                    to_mem.unmap(first_page_info.0, first_page_info.1).expect("Cannot unmap first unaligned page of buffer");;
                 }
 
                 if let Some(middle_page_info) = middle_page_info_opt {
-                    to_mem.unmap(middle_page_info.0, middle_page_info.1);
+                    to_mem.unmap(middle_page_info.0, middle_page_info.1).expect("Cannot unmap buffer");;
                 }
 
                 if let Some(last_page_info) = last_page_info_opt.take() {
-                    to_mem.unmap(last_page_info.0, last_page_info.1);
+                    to_mem.unmap(last_page_info.0, last_page_info.1).expect("Cannot unmap last unaligned page of buffer");;
                 }
 
                 Err(error.into())
@@ -427,7 +427,7 @@ fn buf_unmap(buffer: &Buffer, from_mem: &mut ProcessMemory, to_mem: &mut Process
             };
         }
 
-        from_mem.unmap(addr.floor(), PAGE_SIZE)?;
+        from_mem.unmap(addr.floor(), PAGE_SIZE).expect("Cannot unmap first unaligned page of buffer");
         size_handled += first_page_size;
     }
 
@@ -452,13 +452,13 @@ fn buf_unmap(buffer: &Buffer, from_mem: &mut ProcessMemory, to_mem: &mut Process
 
         }
 
-        from_mem.unmap((addr + size).floor(), PAGE_SIZE)?;
+        from_mem.unmap((addr + size).floor(), PAGE_SIZE).expect("Cannot unmap last unaligned page of buffer");
         size_handled += last_page_size;
     }
 
     assert!((size - size_handled) % PAGE_SIZE == 0, "Remaining size should be a multiple of PAGE_SIZE");
     if size < size_handled {
-        from_mem.unmap(addr.ceil(), size - size_handled)?;
+        from_mem.unmap(addr.ceil(), size - size_handled).expect("Cannot unmap buffer");
     }
 
     result

--- a/kernel/src/ipc/session.rs
+++ b/kernel/src/ipc/session.rs
@@ -27,14 +27,19 @@ use crate::sync::SpinLock;
 use crate::error::UserspaceError;
 use crate::event::Waitable;
 use crate::process::ThreadStruct;
+use crate::sync::MutexGuard;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::slice;
 use byteorder::{LE, ByteOrder};
-use crate::paging::{MappingAccessRights, process_memory::ProcessMemory};
+use crate::paging::{PAGE_SIZE, MappingAccessRights, process_memory::ProcessMemory};
+use crate::paging::process_memory::QueryMemory;
+use crate::paging::mapping::MappingFrames;
 use crate::mem::{UserSpacePtr, UserSpacePtrMut, VirtualAddress};
 use bit_field::BitField;
 use crate::error::KernelError;
 use crate::checks::check_lower_than_usize;
+use sunrise_libkern::MemoryType;
+use sunrise_libutils::align_up;
 
 /// Wrapper around the currently active session and the incoming request list.
 /// They are kept together so they are locked together.
@@ -191,6 +196,25 @@ struct Request {
     /// insert a result (potentially an error) in this option before waking up
     /// the sender.
     answered: Arc<SpinLock<Option<Result<(), UserspaceError>>>>,
+    /// A/B/W buffers that were mapped during the request. We should unmap them
+    /// when replying.
+    buffers: Vec<Buffer>,
+}
+
+/// Information about a Buffer during a Request.
+#[derive(Debug)]
+struct Buffer {
+    /// Is the buffer writable.
+    writable: bool,
+
+    /// The source virtual address of the buffer.
+    source_addr: VirtualAddress,
+
+    /// The destination virtual address of the buffer.
+    dest_addr: VirtualAddress,
+
+    /// The size of the buffer.
+    size: usize,
 }
 
 /// Send an IPC Buffer from the sender into the receiver.
@@ -208,8 +232,10 @@ struct Request {
 /// In practice, the performance lost by memcpying the data can be made up by not
 /// requiring to flush the page table cache, so care must be taken when chosing
 /// between Buffer or Pointer family of IPC.
+///
+/// Should be called from the receiver process.
 #[allow(unused)]
-fn buf_map(from_buf: &[u8], to_buf: &mut [u8], curoff: &mut usize, from_mem: &mut ProcessMemory, to_mem: &mut ProcessMemory, flags: MappingAccessRights) -> Result<(), UserspaceError> {
+fn buf_map(from_buf: &[u8], to_buf: &mut [u8], curoff: &mut usize, from_mem: &mut ProcessMemory, to_mem: &mut ProcessMemory, flags: MappingAccessRights, buffers: &mut Vec<Buffer>) -> Result<(), UserspaceError> {
     let lowersize = LE::read_u32(&from_buf[*curoff..*curoff + 4]);
     let loweraddr = LE::read_u32(&from_buf[*curoff + 4..*curoff + 8]);
     let rest = LE::read_u32(&from_buf[*curoff + 8..*curoff + 12]);
@@ -220,7 +246,7 @@ fn buf_map(from_buf: &[u8], to_buf: &mut [u8], curoff: &mut usize, from_mem: &mu
         .set_bits(32..36, u64::from(rest.get_bits(28..32)))
         .set_bits(36..39, u64::from(rest.get_bits(2..5)));
 
-    let size = *(u64::from(loweraddr))
+    let size = *(u64::from(lowersize))
         .set_bits(32..36, u64::from(rest.get_bits(24..28)));
 
     // 64-bit address on a 32-bit kernel!
@@ -243,12 +269,61 @@ fn buf_map(from_buf: &[u8], to_buf: &mut [u8], curoff: &mut usize, from_mem: &mu
         // BODY: Whatever mechanism we setup for UserSpacePtr, we should probably
         // BODY: reuse it here.
 
-        // Map the descriptor in the other process.
-        return Err(UserspaceError::NotImplemented);
-        /*let mapping = from_mem.share_existing_mapping(VirtualAddress(addr), size)?;
-        let to_addr = to_mem.find_available_space(size)?;
-        to_mem.map_shared_mapping(mapping, to_addr, MappingAccessRights::u_rw())?;
-        to_addr.addr()*/
+        let to_addr_full = to_mem.find_available_space(align_up(size + (addr % PAGE_SIZE), PAGE_SIZE))?;
+        let to_addr = to_addr_full + (addr % PAGE_SIZE);
+
+        let mut size_handled = 0;
+        if addr % PAGE_SIZE != 0 {
+            // memcpy the first page.
+            let first_page_size = core::cmp::min(PAGE_SIZE - (addr % PAGE_SIZE), size);
+
+            let from_mapping = from_mem.mirror_mapping(VirtualAddress(addr), first_page_size)?;
+            let from = UserSpacePtr::from_raw_parts(from_mapping.addr().addr() as *const u8, from_mapping.len());
+
+            to_mem.create_regular_mapping(to_addr_full, PAGE_SIZE, MemoryType::Ipc, MappingAccessRights::u_rw())?;
+            let mut to = UserSpacePtrMut::from_raw_parts_mut(to_addr.addr() as *mut u8, first_page_size);
+            to.copy_from_slice(&from);
+            size_handled += first_page_size;
+        }
+
+        if (addr + size) % PAGE_SIZE != 0 && (to_addr + size).floor() != to_addr_full {
+            // memcpy the last page.
+            let last_page_size = (addr + size) % PAGE_SIZE;
+
+            let from_mapping = from_mem.mirror_mapping((VirtualAddress(addr) + size).floor(), last_page_size)?;
+            let from = UserSpacePtr::from_raw_parts(from_mapping.addr().addr() as *const u8, from_mapping.len());
+
+            let to_last_page = (to_addr + size).floor();
+            to_mem.create_regular_mapping(to_last_page, PAGE_SIZE, MemoryType::Ipc, MappingAccessRights::u_rw())?;
+            let mut to = UserSpacePtrMut::from_raw_parts_mut(to_last_page.addr() as *mut u8, last_page_size);
+
+            to.copy_from_slice(&from);
+            size_handled += last_page_size;
+        }
+
+        if size - size_handled != 0 {
+            // Share middle pages
+            assert!((size - size_handled) % PAGE_SIZE == 0, "Remaining size ({} - {}, {}) should be a multiple of PAGE_SIZE", size, size_handled, size - size_handled);
+
+            let addr = align_up(addr, PAGE_SIZE);
+            let to_addr = to_addr.ceil();
+
+            let mapping = match from_mem.query_memory(VirtualAddress(addr)) {
+                QueryMemory::Used(mapping) => mapping,
+                _ => return Err(UserspaceError::InvalidMemState),
+            };
+
+            let frames = match mapping.frames() {
+                MappingFrames::Shared(shared) => shared.clone(),
+                _ => return Err(UserspaceError::InvalidMemState),
+            };
+
+            let offset = addr - mapping.address().addr();
+
+            to_mem.map_partial_shared_mapping(frames, to_addr, mapping.phys_offset() + offset, size - size_handled, MemoryType::Ipc, MappingAccessRights::u_rw())?;
+        }
+
+        to_addr.addr()
     };
 
     let loweraddr = to_addr as u32;
@@ -262,7 +337,63 @@ fn buf_map(from_buf: &[u8], to_buf: &mut [u8], curoff: &mut usize, from_mem: &mu
     LE::write_u32(&mut to_buf[*curoff + 4..*curoff + 8], loweraddr);
     LE::write_u32(&mut to_buf[*curoff + 8..*curoff + 12], rest);
 
+    buffers.push(Buffer {
+        writable: flags.contains(MappingAccessRights::WRITABLE),
+        source_addr: VirtualAddress(addr),
+        dest_addr: VirtualAddress(to_addr),
+        size
+    });
+
     *curoff += 12;
+    Ok(())
+}
+
+/// Unmap an IPC Buffer from the receiver.
+fn buf_unmap(buffer: &Buffer, from_mem: &mut ProcessMemory, to_mem: &mut ProcessMemory) -> Result<(), UserspaceError> {
+    let addr = buffer.dest_addr;
+    let size = buffer.size;
+    let to_addr = buffer.source_addr;
+    let to_addr_full = to_addr.floor();
+    let mut size_handled = 0;
+
+    if addr.addr() % PAGE_SIZE != 0 {
+        let first_page_size = core::cmp::min(PAGE_SIZE - (addr.addr() % PAGE_SIZE), size);
+
+        if buffer.writable {
+            // memcpy the first page.
+            let from = UserSpacePtr::from_raw_parts(addr.addr() as *const u8, first_page_size);
+            let to_mapping = to_mem.mirror_mapping(to_addr, first_page_size)?;
+            let mut to = UserSpacePtrMut::from_raw_parts_mut(to_mapping.addr().addr() as *mut u8, first_page_size);
+            to.copy_from_slice(&from);
+        }
+
+        from_mem.unmap(addr.floor(), PAGE_SIZE)?;
+        size_handled += first_page_size;
+    }
+
+    if (addr.addr() + size) % PAGE_SIZE != 0 && (to_addr + size).floor() != to_addr_full {
+        let last_page_size = (addr.addr() + size) % PAGE_SIZE;
+
+        if buffer.writable {
+            // memcpy the last page.
+            let from = UserSpacePtr::from_raw_parts((addr.addr() + size) as *const u8, last_page_size);
+
+            let to_last_page = (to_addr + size).floor();
+            let to_mapping = to_mem.mirror_mapping(to_last_page, last_page_size)?;
+            let mut to = UserSpacePtrMut::from_raw_parts_mut(to_mapping.addr().addr() as *mut u8, last_page_size);
+
+            to.copy_from_slice(&from);
+        }
+
+        from_mem.unmap((addr + size).floor(), PAGE_SIZE)?;
+        size_handled += last_page_size;
+    }
+
+    assert!((size - size_handled) % PAGE_SIZE == 0, "Remaining size should be a multiple of PAGE_SIZE");
+    if size < size_handled {
+        from_mem.unmap(addr.ceil(), size - size_handled)?;
+    }
+
     Ok(())
 }
 
@@ -295,6 +426,7 @@ impl ClientSession {
                 sender_bufsize: buf.len(),
                 answered: answered.clone(),
                 sender: scheduler::get_current_thread(),
+                buffers: Vec::new(),
             })
         }
 
@@ -379,11 +511,11 @@ impl ServerSession {
     /// been set by a prior call to wait.
     pub fn receive(&self, mut buf: UserSpacePtrMut<[u8]>, has_c_descriptors: bool) -> Result<(), UserspaceError> {
         // Read active session
-        let internal = self.0.internal.lock();
+        let mut internal = self.0.internal.lock();
 
         // TODO: In case of a race, we might want to check that receive is only called once.
         // Can races even happen ?
-        let active = internal.active_request.as_ref().unwrap();
+        let active = internal.active_request.as_mut().unwrap();
 
         let sender = active.sender.process.clone();
         let memlock = sender.pmemory.lock();
@@ -399,7 +531,7 @@ impl ServerSession {
             CBufBehavior::Disabled
         };
 
-        pass_message(sender_buf, active.sender.clone(), &mut *buf, scheduler::get_current_thread(), false, &*memlock, c_bufs)?;
+        pass_message(sender_buf, active.sender.clone(), &mut *buf, scheduler::get_current_thread(), false, memlock, &mut active.buffers, c_bufs)?;
 
         Ok(())
     }
@@ -421,7 +553,7 @@ impl ServerSession {
         // TODO: This probably has an errcode.
         assert!(self.0.internal.lock().active_request.is_some(), "Called reply without an active session");
 
-        let active = self.0.internal.lock().active_request.take().unwrap();
+        let mut active = self.0.internal.lock().active_request.take().unwrap();
 
         let sender = active.sender.process.clone();
 
@@ -432,7 +564,7 @@ impl ServerSession {
             slice::from_raw_parts_mut(mapping.addr().addr() as *mut u8, mapping.len())
         };
 
-        pass_message(&*buf, scheduler::get_current_thread(), sender_buf, active.sender.clone(), true, &*memlock, CBufBehavior::Disabled)?;
+        pass_message(&*buf, scheduler::get_current_thread(), sender_buf, active.sender.clone(), true, memlock, &mut active.buffers, CBufBehavior::Disabled)?;
 
         *active.answered.lock() = Some(Ok(()));
 
@@ -471,8 +603,8 @@ enum CBufBehavior {
 ///
 /// This function should always be called from the context of the receiver/
 /// server.
-#[allow(unused)]
-fn pass_message(from_buf: &[u8], from_proc: Arc<ThreadStruct>, to_buf: &mut [u8], to_proc: Arc<ThreadStruct>, is_reply: bool, other_memlock: &ProcessMemory, c_bufs: CBufBehavior) -> Result<(), UserspaceError> {
+#[allow(unused, clippy::too_many_arguments)]
+fn pass_message(from_buf: &[u8], from_proc: Arc<ThreadStruct>, to_buf: &mut [u8], to_proc: Arc<ThreadStruct>, is_reply: bool, mut other_memlock: MutexGuard<ProcessMemory>, buffers: &mut Vec<Buffer>, c_bufs: CBufBehavior) -> Result<(), UserspaceError> {
     // TODO: pass_message deadlocks when sending message to the same process.
     // BODY: If from_proc and to_proc are the same process, pass_message will
     // BODY: deadlock trying to acquire the locks to the handle table or the
@@ -596,19 +728,48 @@ fn pass_message(from_buf: &[u8], from_proc: Arc<ThreadStruct>, to_buf: &mut [u8]
     }
 
     if hdr.num_a_descriptors() != 0 || hdr.num_b_descriptors() != 0 {
-        let mut from_mem = from_proc.process.pmemory.lock();
-        let mut to_mem = to_proc.process.pmemory.lock();
+        if is_reply {
+            // TODO: Error to return when replying with A/B/W descriptors
+            // BODY: We currently reply with a broken ass error when replying
+            // BODY: with A/B/W descriptors (which is illegal).
+            return Err(UserspaceError::PortRemoteDead)
+        }
+
+        let mut current_memlock = if is_reply {
+            from_proc.process.pmemory.lock()
+        } else {
+            to_proc.process.pmemory.lock()
+        };
+
+        let (mut from_mem, mut to_mem) = if is_reply {
+            (&mut *current_memlock, &mut *other_memlock)
+        } else {
+            (&mut *other_memlock, &mut *current_memlock)
+        };
 
         for i in 0..hdr.num_a_descriptors() {
-            buf_map(from_buf, to_buf, &mut curoff, &mut *from_mem, &mut *to_mem, MappingAccessRights::empty())?;
+            buf_map(from_buf, to_buf, &mut curoff, &mut *from_mem, &mut *to_mem, MappingAccessRights::empty(), buffers)?;
         }
 
         for i in 0..hdr.num_b_descriptors() {
-            buf_map(from_buf, to_buf, &mut curoff, &mut *from_mem, &mut *to_mem, MappingAccessRights::WRITABLE)?;
+            buf_map(from_buf, to_buf, &mut curoff, &mut *from_mem, &mut *to_mem, MappingAccessRights::WRITABLE, buffers)?;
         }
 
         for i in 0..hdr.num_w_descriptors() {
-            buf_map(from_buf, to_buf, &mut curoff, &mut *from_mem, &mut *to_mem, MappingAccessRights::WRITABLE)?;
+            buf_map(from_buf, to_buf, &mut curoff, &mut *from_mem, &mut *to_mem, MappingAccessRights::WRITABLE, buffers)?;
+        }
+    }
+
+    if is_reply && !buffers.is_empty() {
+        let (mut from_mem, mut to_mem) = if is_reply {
+            (from_proc.process.pmemory.lock(), other_memlock)
+        } else {
+            (other_memlock, to_proc.process.pmemory.lock())
+        };
+
+        // Unmap A-B-W buffers
+        for buffer in buffers {
+            buf_unmap(buffer, &mut *from_mem, &mut *to_mem)?;
         }
     }
 

--- a/kernel/src/paging/cross_process.rs
+++ b/kernel/src/paging/cross_process.rs
@@ -37,6 +37,10 @@ use crate::error::KernelError;
 pub struct CrossProcessMapping {
     /// The KernelLand address it was remapped to. Has the desired offset.
     kernel_address: VirtualAddress,
+    /// Length of the region that was requested to be remapped. Note that the
+    /// actual remapped region may be larger (since a Page Table mapping might
+    /// need to be at least 4KB).
+    len: usize,
     /// The frames this mapping covers.
     mapping: Mapping
 }
@@ -91,6 +95,7 @@ impl CrossProcessMapping {
         }
         Ok(CrossProcessMapping {
             kernel_address: kernel_map_start + (offset % PAGE_SIZE),
+            len,
             mapping: new_mapping
         })
     }
@@ -102,7 +107,7 @@ impl CrossProcessMapping {
 
     /// The length of the region asked to be remapped.
     pub fn len(&self) -> usize {
-        self.mapping.length()
+        self.len
     }
 }
 

--- a/libuser/src/ipc/macros.rs
+++ b/libuser/src/ipc/macros.rs
@@ -275,7 +275,7 @@ macro_rules! object {
     // requirement.
     (@genstruct $ident:ident fields=($($name:ident: $ty:ty),*), ) => {
         #[repr(C)]
-        #[derive(Default, Debug, Clone, Copy)]
+        #[derive(Debug, Clone, Copy)]
         struct $ident {
             $($name: $ty),*
         }
@@ -414,7 +414,7 @@ macro_rules! object {
     // call all the functions to push values to msgout, and push_raw.
     (@genret fields=($($name:ident: $ty:ty),*), retfields=($($rname:ident => $rfn:expr),*), $msgout:expr, $ret:expr, ) => {{
         #[repr(C)]
-        #[derive(Default, Debug, Clone, Copy)]
+        #[derive(Debug, Clone, Copy)]
         struct Ret($($ty,)*);
 
         let ($($rname,)*) = $ret;
@@ -450,7 +450,7 @@ macro_rules! object {
     };
     
     (@copycount ) => { 0 };
-    (@copycount HandleRef, $($tt:tt)*) => {
+    (@copycount HandleRef<$lifetime:lifetime>, $($tt:tt)*) => {
         1 + object!(@copycount $($tt)*)
     };
     (@copycount Handle<copy>, $($tt:tt)*) => {

--- a/libuser/src/types.rs
+++ b/libuser/src/types.rs
@@ -39,6 +39,19 @@ impl Handle {
             lifetime: PhantomData
         }
     }
+
+    /// Creates a new static reference to this handle. See the documentation of
+    /// [HandleRef] for more information.
+    ///
+    /// The kernel guarantees that a Handle is never reused. If the parent [Handle]
+    /// dies before this HandleRef is dropped, every function taking this HandleRef
+    /// will fail with [sunrise_libkern::error::KernelError::InvalidHandle]
+    pub fn as_ref_static(&self) -> HandleRef<'static> {
+        HandleRef {
+            inner: self.0,
+            lifetime: PhantomData
+        }
+    }
 }
 
 impl Drop for Handle {


### PR DESCRIPTION
Properly implement A/B/W buffers in kernel and implement B buffers in libuser.
Also, fix handle<copy> in object! macro.

This is needed by the upcoming time service PR.