### PR TITLE
Clean up usage of byteorder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,6 @@ dependencies = [
  "bit_field 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitfield 0.13.1 (git+https://github.com/sunriseos/rust-bitfield)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -599,7 +598,6 @@ dependencies = [
 name = "sunrise-shell"
 version = "0.1.0"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "gif 0.10.0 (git+https://github.com/SunriseOS/image-gif)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -37,10 +37,6 @@ acpi = { git = "https://github.com/sunriseos/acpi.git" }
 default-features = false
 version = "0.6.10"
 
-[dependencies.byteorder]
-default-features = false
-version = "1.3.2"
-
 [dependencies.hashbrown]
 features = ["nightly"]
 version = "0.5.0"

--- a/kernel/src/process/capabilities.rs
+++ b/kernel/src/process/capabilities.rs
@@ -18,7 +18,7 @@ use failure::Backtrace;
 use bit_field::BitField;
 use bit_field::BitArray;
 use core::fmt;
-use byteorder::{LE, ByteOrder};
+use core::convert::TryInto;
 
 /// Capabilities of a process.
 ///
@@ -162,7 +162,7 @@ impl ProcessCapabilities {
         let mut duplicate_svc = 0;
 
         while let Some(kac) = kac_iter.next() {
-            let kac = LE::read_u32(kac);
+            let kac = u32::from_le_bytes(kac.try_into().expect("Unexpectted kac size"));
             let kac_type = (!kac).trailing_zeros();
             if duplicate_kacs.get_bit(kac_type as _) && KACS_NO_DUPLICATES.get_bit(kac_type as _) {
                 return Err(KernelError::InvalidCombination {
@@ -214,7 +214,7 @@ impl ProcessCapabilities {
                     let _start_page = kac.get_bits(7..31);
                     let _is_ro = kac.get_bit(31);
                     if let Some(kac) = kac_iter.next() {
-                        let kac = LE::read_u32(kac);
+                        let kac = u32::from_le_bytes(kac.try_into().expect("Unexpectted kac size"));
                         if (!kac).trailing_zeros() == MAP_IO_OR_NORMAL_RANGE {
                             let _num_pages = kac.get_bits(7..31);
                             let _is_io = kac.get_bit(31);

--- a/libuser/src/ipc/mod.rs
+++ b/libuser/src/ipc/mod.rs
@@ -13,7 +13,7 @@
 //! In libuser, we don't make a proper distinction between Cmif and Hipc. Both
 //! are implemented in the same layer, which is backed by the Message structure.
 
-
+use core::convert::TryInto;
 use core::marker::PhantomData;
 use core::mem;
 use core::convert::TryFrom;
@@ -1039,7 +1039,7 @@ fn find_ty_cmdid(buf: &[u8]) -> Option<(u16, u32)> {
     if buf.len() < 8 {
         return None
     }
-    let hdr = LE::read_u64(&buf[0..8]);
+    let hdr = u64::from_le_bytes(buf[0..8].try_into().expect("cmd header is invalid"));
     let ty = hdr.get_bits(0..16) as u16;
     let x_descs = hdr.get_bits(16..20) as usize;
     let a_descs = hdr.get_bits(20..24) as usize;
@@ -1049,7 +1049,7 @@ fn find_ty_cmdid(buf: &[u8]) -> Option<(u16, u32)> {
         if buf.len() < 12 {
             return None
         }
-        let dsc = LE::read_u32(&buf[8..12]);
+        let dsc = u32::from_le_bytes(buf[8..12].try_into().expect("cmd description is invalid"));
         (dsc.get_bit(0) as usize, dsc.get_bits(1..5) as usize, dsc.get_bits(5..9) as usize)
     } else {
         (0, 0, 0)
@@ -1059,7 +1059,7 @@ fn find_ty_cmdid(buf: &[u8]) -> Option<(u16, u32)> {
     if buf.len() < raw + 4 {
         return None
     }
-    let cmdid = LE::read_u32(&buf[raw..raw + 4]);
+    let cmdid = u32::from_le_bytes(buf[raw..raw + 4].try_into().expect("command id is invalid"));
     Some((ty, cmdid))
 }
 

--- a/libuser/src/ipc/mod.rs
+++ b/libuser/src/ipc/mod.rs
@@ -17,7 +17,7 @@ use core::convert::TryInto;
 use core::marker::PhantomData;
 use core::mem;
 use core::convert::TryFrom;
-use byteorder::{ByteOrder, LE};
+use byteorder::LE;
 use arrayvec::{ArrayVec, Array};
 use crate::utils::{self, align_up, CursorWrite, CursorRead};
 use crate::types::{Handle, HandleRef, Pid};

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -11,10 +11,6 @@ log = "0.4.6"
 sunrise-libuser = { path = "../libuser" }
 spin = "0.5"
 
-[dependencies.byteorder]
-default-features = false
-version = "1.3.2"
-
 [dependencies.lazy_static]
 features = ["spin_no_std"]
 version = "1.3.0"

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -39,7 +39,6 @@ use core::fmt::Write;
 use alloc::vec::Vec;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
-use byteorder::{ByteOrder, LE};
 use spin::Mutex;
 
 fn main() {
@@ -55,7 +54,7 @@ fn main() {
             "test_divide_by_zero" => test_divide_by_zero(),
             "test_page_fault" => test_page_fault(),
             "connect" => {
-                let handle = sm::IUserInterfaceProxy::raw_new().unwrap().get_service(LE::read_u64(b"vi:\0\0\0\0\0"));
+                let handle = sm::IUserInterfaceProxy::raw_new().unwrap().get_service(u64::from_le_bytes(*b"vi:\0\0\0\0\0"));
                 let _ = writeln!(&mut terminal, "Got handle {:?}", handle);
             },
             "exit" => return,


### PR DESCRIPTION
This remove dependency on byteorder in the kernel and shell.
Also reduce usage of byteorder in libuser

Related to #332