### PR TITLE
Add process handle, and thread/proc meta-handles.

### DIFF
--- a/swipc-gen/src/gen_rust_code.rs
+++ b/swipc-gen/src/gen_rust_code.rs
@@ -158,7 +158,9 @@ fn get_handle_type(ty: &Option<HandleType>) -> Option<&'static str> {
         Some(HandleType::ClientPort)    => Some("sunrise_libuser::types::ClientPort"),
         Some(HandleType::ServerPort)    => Some("sunrise_libuser::types::ServerPort"),
         Some(HandleType::SharedMemory)  => Some("sunrise_libuser::types::SharedMemory"),
-        _                                => None
+        Some(HandleType::Process)       => Some("sunrise_libuser::types::Process"),
+        Some(HandleType::Thread)        => Some("sunrise_libuser::types::Thread"),
+        _                               => None
     }
 }
 


### PR DESCRIPTION
0xFFFF8000 and 0xFFFF8001 now point to the current thread and current
process respectively. Those meta-handles are valid in almost all
contexts.