### PR TITLE
More useful swipc-gen Makefile.toml rule.

### DIFF
--- a/swipc-gen/src/lib.rs
+++ b/swipc-gen/src/lib.rs
@@ -53,7 +53,7 @@ pub fn gen_ipc(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let id_file = fs::read_to_string(&root.join("src/").join(&args.path)).unwrap();
 
-    let mut generated_mod = gen_rust_code::generate_ipc(&id_file, prefix, item.ident.to_string(), crate_name);
+    let mut generated_mod = gen_rust_code::generate_ipc(&id_file, prefix, item.ident.to_string(), crate_name, false);
 
     // Force a rebuild if the SwIPC definition changes.
     writeln!(generated_mod).unwrap();


### PR DESCRIPTION
`cargo make swipc-gen sunrise_libuser::vi ipcdefs/vi.id` will now generate a file under sunrise_libuser/src/vi.rs containing the module. You can simply turn the module declaration in sunrise_libuser/src/lib.rs into `mod vi;` and get better compilation errors.