### PR TITLE
Revert "Bump xmas-elf from 0.6.2 to 0.7.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,7 +519,7 @@ dependencies = [
  "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libutils 0.1.0",
- "xmas-elf 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xmas-elf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -552,7 +552,7 @@ dependencies = [
  "static_assertions 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libkern 0.1.0",
  "sunrise-libutils 0.1.0",
- "xmas-elf 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xmas-elf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -740,7 +740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xmas-elf"
-version = "0.7.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "zero 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -833,5 +833,5 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum xmas-elf 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e74de9a366f6ab8c405fa6b371d9ac24943921fa14b3d64afcb202065c405f11"
+"checksum xmas-elf 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "22678df5df766e8d1e5d609da69f0c3132d794edf6ab5e75e7abcd2270d4cf58"
 "checksum zero 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5f1bc8a6b2005884962297587045002d8cfb8dcec9db332f4ca216ddc5de82c5"

--- a/bootstrap/Cargo.toml
+++ b/bootstrap/Cargo.toml
@@ -15,7 +15,7 @@ bit_field = "0.10.0"
 bitflags = "1.1"
 multiboot2 = { git = "https://github.com/sunriseos/multiboot2-elf64.git" }
 spin = "0.5.0"
-xmas-elf = "0.7.0"
+xmas-elf = "0.6.2"
 
 [dependencies.smallvec]
 default-features = false

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -26,7 +26,7 @@ multiboot2 = { git = "https://github.com/sunriseos/multiboot2-elf64.git" }
 spin = "0.5"
 linked_list_allocator = "0.6.4"
 log = "0.4.6"
-xmas-elf = "0.7.0"
+xmas-elf = "0.6.2"
 rustc-demangle = "0.1"
 failure = { version = "0.1", default-features = false, features = ["derive"] }
 bitfield = { git = "https://github.com/sunriseos/rust-bitfield" }


### PR DESCRIPTION
This reverts commit 014dc1891e4a35a2ec5743eeaf64a2bed270b780.

Addressing #374

xmas_elf does an out of bound access when loading vi, causing a kernel panic.

Reverting the last update of xmas_elf seems to fix the problem, use this until we figure out where this bug comes from.