### PR TITLE
Linker: kernel and bootstrap .rodata RO

### DIFF
--- a/bootstrap/src/gdt/mod.rs
+++ b/bootstrap/src/gdt/mod.rs
@@ -18,7 +18,7 @@ use core::fmt::Write;
 use self::segment_selector::SegmentSelector;
 use self::i386::{PrivilegeLevel, TssStruct};
 
-#[cfg_attr(not(test), link_section = ".gdt")]
+/// The GDT set-up by the bootstrap
 static GDT: Once<DescriptorTable> = Once::new();
 
 /// The global LDT used by all the processes.

--- a/linker-scripts/bootstrap.ld
+++ b/linker-scripts/bootstrap.ld
@@ -4,7 +4,6 @@ OUTPUT_FORMAT(elf32-i386)
 PHDRS
 {
   boot PT_LOAD ;
-  gdt  PT_LOAD ;
   text PT_LOAD ;
   rodata PT_LOAD ;
   data PT_LOAD ;
@@ -17,10 +16,6 @@ SECTIONS {
 	.boot ALIGN(4K) : {
 		KEEP(*(.multiboot_header))
 	} : boot
-
-	.gdt ALIGN(4K) : {
-		*(.gdt)
-	}
 
 	. = 1M;
 

--- a/linker-scripts/bootstrap.ld
+++ b/linker-scripts/bootstrap.ld
@@ -6,6 +6,7 @@ PHDRS
   boot PT_LOAD ;
   gdt  PT_LOAD ;
   text PT_LOAD ;
+  rodata PT_LOAD ;
   data PT_LOAD ;
   dynamic PT_DYNAMIC ;
 }
@@ -27,12 +28,12 @@ SECTIONS {
 		*(.text .text.*)
 	} : text
 
-	.data ALIGN(4K) : {
-		*(.data .data.*)
-	} : data
-
 	.rodata ALIGN(4K) : {
 		*(.rodata .rodata.*)
+	} : rodata
+
+	.data ALIGN(4K) : {
+		*(.data .data.*)
 	} : data
 
 	.got ALIGN(4K) : {

--- a/linker-scripts/kernel.ld
+++ b/linker-scripts/kernel.ld
@@ -4,6 +4,7 @@ OUTPUT_FORMAT(elf32-i386)
 PHDRS
 {
   text PT_LOAD ;
+  rodata PT_LOAD ;
   data PT_LOAD ;
   dynamic PT_DYNAMIC ;
 }
@@ -19,12 +20,12 @@ SECTIONS {
 		*(.text .text.*)
 	} : text
 
-	.data ALIGN(4K) : {
-		*(.data .data.*)
-	} : data
-
 	.rodata ALIGN(4K) : {
 		*(.rodata .rodata.*)
+	} : rodata
+
+	.data ALIGN(4K) : {
+		*(.data .data.*)
 	} : data
 
 	.got ALIGN(4K) : {


### PR DESCRIPTION
The linker scripts for kernel and bootstrap now put `.rodata` in its own segment, so it can be read-only.

Fixes #369