### PR TITLE
Use rust backend for miniz

### DIFF
--- a/time/build-script/Cargo.toml
+++ b/time/build-script/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 tar = "0.4"
-flate2 = "1.0"
+flate2 = { version = "1.0", features = ["rust_backend"] }


### PR DESCRIPTION
Removes a C dependency that fails to compile sometimes on windows.

See https://github.com/alexcrichton/flate2-rs/issues/27