### PR TITLE
todo-bot: touch TLS todos

### DIFF
--- a/kernel/src/paging/arch/mod.rs
+++ b/kernel/src/paging/arch/mod.rs
@@ -7,5 +7,5 @@ pub use self::i386::table::{ActiveHierarchy, InactiveHierarchy};
 pub use self::i386::entry::I386Entry as Entry;
 pub use self::i386::entry::I386EntryFlags as EntryFlags;
 pub use self::i386::is_paging_on;
-pub use self::i386::{read_cr2, read_cr3}; // TODO: expose current page directory's address in an arch-independant way.
+pub use self::i386::{read_cr2, read_cr3}; // todo: expose current page directory's address in an arch-independant way.
 pub use self::i386::lands::{KernelLand, UserLand, RecursiveTablesLand};

--- a/kernel/src/panic.rs
+++ b/kernel/src/panic.rs
@@ -61,8 +61,8 @@ pub enum PanicOrigin<'a> {
 /// Takes a panic origin, so we can personalize the kernel panic message.
 pub fn kernel_panic(panic_origin: &PanicOrigin) -> ! {
 
-    // TODO: permanently_disable_interrupts shouldn't be unsafe.
-    // BODY: disabling interrupts doesn't break any safety guidelines, and is perfectly safe as far as rustc is concerned.
+    // todo: permanently_disable_interrupts shouldn't be unsafe.
+    // body: disabling interrupts doesn't break any safety guidelines, and is perfectly safe as far as rustc is concerned.
     // Disable interrupts forever!
     unsafe { sync::permanently_disable_interrupts(); }
     // Don't deadlock in the logger
@@ -183,12 +183,12 @@ pub fn kernel_panic(panic_origin: &PanicOrigin) -> ! {
         let _ = writeln!(SerialLogger, "Panic handler: Failed to get kernel elf symbols");
     }
 
-    // todo: Kernel Stack dump update
-    // body: Update the kernel stack dump functions to be compatible the new and improved
-    // body: kernel panic.
-    // body:
-    // body: Now that know the origin (userspace or kernelspace) in the panic, this should
-    // body: be easy, and we can finally have userspace stack dumps that actually work.
+    // TODO: Kernel Stack dump update
+    // BODY: Update the kernel stack dump functions to be compatible the new and improved
+    // BODY: kernel panic.
+    // BODY:
+    // BODY: Now that know the origin (userspace or kernelspace) in the panic, this should
+    // BODY: be easy, and we can finally have userspace stack dumps that actually work.
     let stackdump_source = None;
 
     // Then print the stack

--- a/libuser/src/threads.rs
+++ b/libuser/src/threads.rs
@@ -206,14 +206,14 @@ impl Thread {
     /// Allocates the stack, sets up the context and TLS, and calls `svcCreateThread`.
     ///
     /// [`start`]: Thread::start
-    // TODO: Libuser Thread stack guard
-    // BODY: Currently the stack of every non-main thread is allocated in the heap, and no page
-    // BODY: guard protects from stack-overflowing and rewriting all the heap.
-    // BODY:
-    // BODY: This is of course terrible for security, as with this stack overflowing is U.B.
-    // BODY:
-    // BODY: The simpler way to fix this would be to continue allocating the stack on the heap,
-    // BODY: but remap the last page with no permissions with the yet unimplemented svcMapMemory syscall.
+    // todo: Libuser Thread stack guard
+    // body: Currently the stack of every non-main thread is allocated in the heap, and no page
+    // body: guard protects from stack-overflowing and rewriting all the heap.
+    // body:
+    // body: This is of course terrible for security, as with this stack overflowing is U.B.
+    // body:
+    // body: The simpler way to fix this would be to continue allocating the stack on the heap,
+    // body: but remap the last page with no permissions with the yet unimplemented svcMapMemory syscall.
     pub fn create(entry: fn (usize) -> (), arg: usize) -> Result<Self, Error> {
 
         let tls_elf = Once::new();
@@ -294,11 +294,11 @@ extern "fastcall" fn thread_trampoline(thread_context_addr: usize) -> ! {
 
 impl Drop for Thread {
     fn drop(&mut self) {
-        // todo: Properly free resource after thread detach
-        // body: When detaching a thread, we should ensure that the associated resources (stack,
-        // body: handle, context, etc...) are properly freed before the Process exits. This can be
-        // body: done by adding the ThreadContext to a global Vec<> of ThreadContext that gets freed
-        // body: when the main thread (or the last thread alive?) exits.
+        // TODO: Properly free resource after thread detach
+        // BODY: When detaching a thread, we should ensure that the associated resources (stack,
+        // BODY: handle, context, etc...) are properly freed before the Process exits. This can be
+        // BODY: done by adding the ThreadContext to a global Vec<> of ThreadContext that gets freed
+        // BODY: when the main thread (or the last thread alive?) exits.
     }
 }
 


### PR DESCRIPTION
Because the TLS PR is so big, todobot bailed on it.

Make a PR that only touches every `// todo:` we opened in #339, so todobot picks them again.