### PR TITLE
SM: Fix hang when multiple futures wait on EVENT

### DIFF
--- a/sm/src/main.rs
+++ b/sm/src/main.rs
@@ -167,9 +167,10 @@ impl IUserInterfaceAsync for UserInterface {
                 futures::future::ready(Loop::Break(client)).left_future()
             } else {
                 debug!("Service {} not currently registered. Sleeping.", servicename);
-                SERVICES_EVENT.1.wait_async(work_queue.clone())
+                SERVICES_EVENT.1.wait_async_cb(work_queue.clone(), move || {
+                    SERVICES.lock().contains_key(&servicename)
+                })
                     .map(|_| {
-                        SERVICES_EVENT.1.clear().unwrap();
                         Loop::Continue(work_queue)
                     }).right_future()
             }


### PR DESCRIPTION
We used to have a bit of a hard-to-debug hang in sm when multiple
futures wait on SERVICE_EVENT. Here's what would happen: Multiple
futures would call get_service on a service that does not exist yet, and
end up waiting on SERVICE_EVENT. Let's call those services "a" and "b".
Then, a service "a" and "b" would both get registered through register_event.

This would cause the event to get triggered, waking up the service waiting on
"a". The future would check if the handle is actually triggered (to
handle spurious wakeups) with a call to wait_synchronization, and then
clear the event and return the session.

Then "b" gets woken up and goes through the same process. Except the
event was cleared, so the call to wait_synchronization will return
false!

The mistake is that when the future wakeup, we don't *actually* care
about the state the event is in. What we care about is if the service is
registered. So what we do is, we add a new function that allows treating
the event more like a semaphore. This function takes a callback
returning a bool. The future will be considered ready when that callback
returns true. When it returns false, the future will clear the event,
register it on the event loop, and return pending.