### PR TITLE
Switch to bitfield official releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,11 +51,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitfield"
-version = "0.13.1"
-source = "git+https://github.com/sunriseos/rust-bitfield#0fe12f3bf50d9afbbf2c73f627aad73558a679cf"
-
-[[package]]
-name = "bitfield"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -729,7 +724,7 @@ version = "0.1.0"
 dependencies = [
  "acpi 0.1.0 (git+https://github.com/sunriseos/acpi.git)",
  "bit_field 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitfield 0.13.1 (git+https://github.com/sunriseos/rust-bitfield)",
+ "bitfield 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1004,7 +999,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
 "checksum bit_field 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a165d606cf084741d4ac3a28fb6e9b1eb0bd31f6cd999098cfddb0b2ab381dc0"
 "checksum bit_field 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed8765909f9009617974ab6b7d332625b320b33c326b1e9321382ef1999b5d56"
-"checksum bitfield 0.13.1 (git+https://github.com/sunriseos/rust-bitfield)" = "<none>"
 "checksum bitfield 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"

--- a/ahci/Cargo.toml
+++ b/ahci/Cargo.toml
@@ -10,7 +10,7 @@ sunrise-libuser = { path = "../libuser" }
 sunrise-libutils = { path = "../libutils" }
 spin = "0.5"
 log = "0.4.6"
-bitfield = "0.13.1"
+bitfield = "0.13"
 futures-preview = { version = "0.3.0-alpha.16", default-features = false, features = ["nightly", "alloc"] }
 
 [dependencies.lazy_static]

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -29,7 +29,7 @@ log = "0.4.6"
 xmas-elf = "0.7.0"
 rustc-demangle = "0.1"
 failure = { version = "0.1", default-features = false, features = ["derive"] }
-bitfield = { git = "https://github.com/sunriseos/rust-bitfield" }
+bitfield = "0.13"
 mashup = "0.1.9"
 tinybmp = "0.1.0"
 acpi = { git = "https://github.com/sunriseos/acpi.git" }


### PR DESCRIPTION
We don't need to use our own fork anymore as it has been upstream.

Also make sure that AHCI doesn't use a specific version number.