### PR TITLE
Kernel: unconditionally switch gs entering kernel

### DIFF
--- a/kernel/src/i386/interrupt_service_routines.rs
+++ b/kernel/src/i386/interrupt_service_routines.rs
@@ -245,10 +245,6 @@ macro_rules! trap_gate_asm {
         mov eax, [esp + 0x2C] // cs is 11 registers away at that time * 4 bytes / reg
         push eax
 
-        // Load kernel tls segment
-        mov ax, 0x18
-        mov gs, ax
-
         jmp 2f
     1: // else if priv unchanged
         // cpu did not push an esp, we are still running on the same stack: compute it
@@ -261,6 +257,10 @@ macro_rules! trap_gate_asm {
         push esp
 
         // Great, registers are now fully backed up
+
+        // Load kernel tls segment
+        mov ax, 0x18
+        mov gs, ax
 
         // Call some rust code, passing it a pointer to the UserspaceHardwareContext
         call $0


### PR DESCRIPTION
When entering the kernel (e.g. syscall), we need to switch `gs` from GdtIndex::UTlsElf to GdtIndex::KTls, so the kernel can access its cpu-locals.

When re-entering the kernel (e.g. interrupt while handling a syscall), it would seem we don't need to switch `gs` again, since the first entry should have already done it for us. This was the politic that we followed.

However it turns out that sometimes during a syscall the cpu re-interrupts us while we're still in the first interrupt handler, before we had time to set `gs`. The second interrupt handler assumes gs is already valid, and we end up in the kernel with `gs` pointing to GdtIndex::UTlsElf: that's a page fault waiting to happen.

![Screen Shot 2019-08-27 at 2 23 47 PM](https://user-images.githubusercontent.com/6343527/63774678-0beeb900-c8de-11e9-93e4-3d66e07531bd.png)

Fix this by unconditionally set `gs` to GdtIndex::KTls in interrupt handlers.