### PR TITLE
Rewrite timer to support oneshot

### DIFF
--- a/kernel/src/devices/hpet.rs
+++ b/kernel/src/devices/hpet.rs
@@ -336,8 +336,10 @@ impl HpetTimer {
 
 impl Hpet {
     /// The minimal precision we are going to use for the HPET in femtosecond.
-    ///
-    /// By specs, the minimal frequency of the HPET is 10Mhz, so our minimal resolution can be 100 nanoseconds.
+    /// 
+    // TODO: Switch to a lower update frequency in HPET 
+    // BODY: By specs, the minimal frequency of the HPET is 10Mhz, so our minimal precision can be 100 nanoseconds but for now it's 1 milliseconds.
+    // BODY: For that to be possible, we need to take care of the sleep_thread logic and usage in the userland drivers (e.g: AHCI).
     const PRECISION_FS: u64 = 1_000_000 * 1_000_000;
 
     /// Create a new HPET device instance from MMIO registers.

--- a/kernel/src/devices/hpet.rs
+++ b/kernel/src/devices/hpet.rs
@@ -486,7 +486,7 @@ impl timer::TimerDriver for Hpet {
         self.get_main_counter_value() + ticks
     }
 
-    fn is_after_or_equal_target_ticks(&self, target_ticks: u64) -> bool {
+    fn is_after_or_equal_main_ticks(&self, target_ticks: u64) -> bool {
         self.get_main_counter_value() >= target_ticks
     }
 

--- a/kernel/src/devices/hpet.rs
+++ b/kernel/src/devices/hpet.rs
@@ -487,7 +487,7 @@ impl timer::TimerDriver for Hpet {
     }
 
     fn is_after_or_equal_main_ticks(&self, target_ticks: u64) -> bool {
-        self.get_main_counter_value() >= target_ticks
+        target_ticks >= self.get_main_counter_value()
     }
 
     /// Convert the given nanoseconds to timer ticks.

--- a/kernel/src/devices/hpet.rs
+++ b/kernel/src/devices/hpet.rs
@@ -15,6 +15,9 @@ use core::fmt::Formatter;
 
 use crate::timer;
 
+use spin::Once;
+use crate::sync::SpinLockIRQ;
+
 bitfield! {
     /// Represent the lower part of the General Capabilities and ID Register.
     #[derive(Clone, Copy, Debug)]
@@ -147,7 +150,7 @@ pub struct HpetTimerRegister {
 /// Represent an HPET device.
 pub struct Hpet {
     /// The mmio address of this HPET device.
-    pub inner: *mut HpetRegister,
+    pub inner: &'static mut HpetRegister,
 
     /// Cached value of ``Hpet::period``.
     period: u32,
@@ -160,7 +163,7 @@ pub struct Hpet {
 /// Represent an HPET timer.
 pub struct HpetTimer {
     /// The mmio address of this HPET timer.
-    inner: *mut HpetTimerRegister,
+    inner: &'static mut HpetTimerRegister,
 
     /// Cached value of ``HpetTimerConfigurationRegister::size_capability``.
     support_64bit: bool,
@@ -180,21 +183,26 @@ impl HpetTimer {
     const MAX_IRQ: u32 = 0x1F;
 
     /// Create a new HPET timer instance from MMIO registers.
-    fn new(inner: *mut HpetTimerRegister) -> Self {
+    ///
+    /// # Safety
+    ///
+    /// If inner is mutably aliased, this will cause UB. We need to ensure that
+    /// we are the unique owner of the HpetTimerRegister pointer.
+    unsafe fn new(inner: *mut HpetTimerRegister) -> Self {
         let mut res = HpetTimer {
-            inner,
+            inner: inner.as_mut().unwrap(),
             support_64bit: false,
             support_periodic_interrupt: false,
             support_fsb_interrupt: false,
             interrupt_route_capability: 0,
         };
 
-        let config = unsafe { (*inner).config.read() };
+        let config = res.inner.config.read();
 
         res.support_64bit = config.size_capability();
         res.support_periodic_interrupt = config.periodic_interrupt_capability();
         res.support_fsb_interrupt = config.fsb_interrupt_capability();
-        res.interrupt_route_capability = unsafe { (*inner).interrupt_route_capability.read() };
+        res.interrupt_route_capability = res.inner.interrupt_route_capability.read();
         res
     }
 
@@ -228,28 +236,24 @@ impl HpetTimer {
     /// # Panics
     ///
     /// Panics if the given interrupt route is not supported by this hpet timer.
-    pub fn set_interrupt_route(&self, index: u32) {
+    pub fn set_interrupt_route(&mut self, index: u32) {
         assert!(self.support_interrupt_routing(index), "Illegal interrupt route (as claimed). Supported routes: {}.", self.interrupt_route_capability);
-        let mut config = unsafe { (*self.inner).config.read() };
+        let mut config = self.inner.config.read();
         config.set_interrupt_route(index);
-        unsafe { (*self.inner).config.write(config); }
+        self.inner.config.write(config);
 
-        let config = unsafe { (*self.inner).config.read() };
+        let config = self.inner.config.read();
         assert!(config.interrupt_route() == index, "Illegal interrupt route (as tested). Supported routes: {}.", self.interrupt_route_capability);
     }
 
     /// Set the timer comparactor value
-    pub fn set_comparator_value(&self, value: u64) {
-        unsafe {
-            (*self.inner)
-                .comparator_value_low
-                .write((value & 0xFFFF_FFFF) as u32)
-        };
-        unsafe {
-            (*self.inner)
-                .comparator_value_high
-                .write((value >> 32) as u32)
-        };
+    pub fn set_comparator_value(&mut self, value: u64) {
+        self.inner
+            .comparator_value_low
+            .write((value & 0xFFFF_FFFF) as u32);
+        self.inner
+            .comparator_value_high
+            .write((value >> 32) as u32);
     }
 
     /// Set the timer accumulator value.
@@ -257,50 +261,46 @@ impl HpetTimer {
     /// # Note
     ///
     /// The timer MUST be in periodic mode.
-    pub fn set_accumulator_value(&self, value: u64) {
+    pub fn set_accumulator_value(&mut self, value: u64) {
         // We update the accumulator register two times.
         // TODO: Test the hardware behaviour on partial write of the HPET accumulator
         // BODY: Because we are running on i386, this cause issue on QEMU.
         // BODY: In fact, QEMU clear the accumulator flag on every partial write.
         // BODY: The question here is: Is that normal or a bug in QEMU?
-        let mut config = unsafe { (*self.inner).config.read() };
+        let mut config = self.inner.config.read();
         config.set_accumulator_config(true);
-        unsafe { (*self.inner).config.write(config) };
-        unsafe {
-            (*self.inner)
-                .comparator_value_low
-                .write((value & 0xFFFF_FFFF) as u32)
-        };
+        self.inner.config.write(config);
+        self.inner
+            .comparator_value_low
+            .write((value & 0xFFFF_FFFF) as u32);
 
-        let mut config = unsafe { (*self.inner).config.read() };
+        let mut config = self.inner.config.read();
         config.set_accumulator_config(true);
-        unsafe { (*self.inner).config.write(config) };
-        unsafe {
-            (*self.inner)
-                .comparator_value_high
-                .write((value >> 32) as u32)
-        };
+        self.inner.config.write(config);
+        self.inner
+            .comparator_value_high
+            .write((value >> 32) as u32);
     }
 
     /// Set Edge Trigger.
-    pub fn set_edge_trigger(&self) {
-        let mut config = unsafe { (*self.inner).config.read() };
+    pub fn set_edge_trigger(&mut self) {
+        let mut config = self.inner.config.read();
         config.set_interrupt_type(false);
-        unsafe { (*self.inner).config.write(config) };
+        self.inner.config.write(config);
     }
 
     /// Set Level Trigger.
-    pub fn set_level_trigger(&self) {
-        let mut config = unsafe { (*self.inner).config.read() };
+    pub fn set_level_trigger(&mut self) {
+        let mut config = self.inner.config.read();
         config.set_interrupt_type(true);
-        unsafe { (*self.inner).config.write(config) };
+        self.inner.config.write(config);
     }
 
     /// Set the timer in One Shot mode.
-    pub fn set_one_shot_mode(&self) {
-        let mut config = unsafe { (*self.inner).config.read() };
+    pub fn set_one_shot_mode(&mut self) {
+        let mut config = self.inner.config.read();
         config.set_timer_type(false);
-        unsafe { (*self.inner).config.write(config) };
+        self.inner.config.write(config);
     }
 
     /// Set the timer in Periodic mode.
@@ -308,50 +308,59 @@ impl HpetTimer {
     /// # Note
     ///
     /// The timer must support periodic mode.
-    pub fn set_periodic_mode(&self) {
-        let mut config = unsafe { (*self.inner).config.read() };
+    pub fn set_periodic_mode(&mut self) {
+        let mut config = self.inner.config.read();
         config.set_timer_type(true);
-        unsafe { (*self.inner).config.write(config) };
+        self.inner.config.write(config);
     }
 
     /// Enable interrupt.
-    pub fn enable_interrupt(&self) {
-        let mut config = unsafe { (*self.inner).config.read() };
+    pub fn enable_interrupt(&mut self) {
+        let mut config = self.inner.config.read();
         config.set_interrupt_enable(true);
-        unsafe { (*self.inner).config.write(config) };
+        self.inner.config.write(config);
     }
 
     /// Disable interrupt.
-    pub fn disable_interrupt(&self) {
-        let mut config = unsafe { (*self.inner).config.read() };
+    pub fn disable_interrupt(&mut self) {
+        let mut config = self.inner.config.read();
         config.set_interrupt_enable(false);
-        unsafe { (*self.inner).config.write(config) };
+        self.inner.config.write(config);
     }
 
     /// Determine if the interrupt is enabled.
     pub fn has_interrupt_enabled(&self) -> bool {
-        unsafe { (*self.inner).config.read().interrupt_enable() }
+        self.inner.config.read().interrupt_enable()
     }
 }
 
 impl Hpet {
+    /// The minimal precision we are going to use for the HPET in femtosecond.
+    ///
+    /// By specs, the minimal frequency of the HPET is 10Mhz, so our minimal resolution can be 100 nanoseconds.
+    const PRECISION_FS: u64 = 1_000_000 * 1_000_000;
+
     /// Create a new HPET device instance from MMIO registers.
-    fn new(inner: *mut HpetRegister) -> Self {
+    ///
+    /// # Safety
+    ///
+    /// We take ownership of inner, it should be a unique pointer.
+    unsafe fn new(inner: *mut HpetRegister) -> Self {
         debug!("Creating new HPET with registers at {:p}", inner);
         let mut res = Hpet {
-            inner,
+            inner: inner.as_mut().unwrap(),
             timer_count: 1,
             period: 0,
         };
-        res.timer_count = unsafe { (*res.inner).identifier.read().timer_count_minus_one() } + 1;
-        res.period = unsafe { (*res.inner).period.read() };
+        res.timer_count = res.inner.identifier.read().timer_count_minus_one() + 1;
+        res.period = res.inner.period.read();
 
         res
     }
 
     /// Return true if the device supports "legacy mapping".
     pub fn has_legacy_mapping(&self) -> bool {
-        unsafe { (*self.inner).identifier.read().legacy_rt_capability() }
+        self.inner.identifier.read().legacy_rt_capability()
     }
 
     /// Return the period of the HPET device.
@@ -365,72 +374,63 @@ impl Hpet {
     }
 
     /// Enable the "legacy mapping".
-    pub fn enable_legacy_mapping(&self) {
-        let mut general_configuration = unsafe { (*self.inner).general_configuration.read() };
+    pub fn enable_legacy_mapping(&mut self) {
+        let mut general_configuration = self.inner.general_configuration.read();
         general_configuration.set_legacy_rt_config(true);
-        unsafe {
-            (*self.inner)
-                .general_configuration
-                .write(general_configuration)
-        }
+        self.inner
+            .general_configuration
+            .write(general_configuration)
     }
 
     /// Disable the "legacy mapping".
-    pub fn disable_legacy_mapping(&self) {
-        let mut general_configuration = unsafe { (*self.inner).general_configuration.read() };
+    pub fn disable_legacy_mapping(&mut self) {
+        let mut general_configuration = self.inner.general_configuration.read();
         general_configuration.set_legacy_rt_config(false);
-        unsafe {
-            (*self.inner)
-                .general_configuration
-                .write(general_configuration)
-        }
+        self.inner
+            .general_configuration
+            .write(general_configuration)
     }
 
     /// Check "legacy mapping" status.
     pub fn is_legacy_mapping_enabled(&self) -> bool {
-        let general_configuration = unsafe { (*self.inner).general_configuration.read() };
+        let general_configuration = self.inner.general_configuration.read();
         general_configuration.legacy_rt_config()
     }
 
     /// Enable HPET (main timer running, and timer interrupts allowed).
-    pub fn enable(&self) {
-        let mut general_configuration = unsafe { (*self.inner).general_configuration.read() };
+    pub fn enable(&mut self) {
+        let mut general_configuration = self.inner.general_configuration.read();
         general_configuration.set_enable_config(true);
-        unsafe {
-            (*self.inner)
-                .general_configuration
-                .write(general_configuration)
-        }
+        self.inner
+            .general_configuration
+            .write(general_configuration)
     }
 
     /// Set HPET main counter value.
-    pub fn set_main_counter_value(&self, value: u64) {
-        unsafe {
-            (*self.inner)
-                .main_counter_value
-                .write(value)
-        }
+    pub fn set_main_counter_value(&mut self, value: u64) {
+        self.inner
+            .main_counter_value
+            .write(value)
     }
 
     /// Get HPET main counter value.
     pub fn get_main_counter_value(&self) -> u64 {
-        unsafe { (*self.inner).main_counter_value.read() }
+        self.inner.main_counter_value.read()
     }
 
     /// Disable HPET (main timer halted, and timer interrupts disabled).
-    pub fn disable(&self) {
-        let mut general_configuration = unsafe { (*self.inner).general_configuration.read() };
+    pub fn disable(&mut self) {
+        let mut general_configuration = self.inner.general_configuration.read();
         general_configuration.set_enable_config(false);
-        unsafe {
-            (*self.inner)
-                .general_configuration
-                .write(general_configuration)
-        }
+
+        self.inner
+            .general_configuration
+            .write(general_configuration)
     }
 
     /// Check HPET status.
     pub fn is_enabled(&self) -> bool {
-        let general_configuration = unsafe { (*self.inner).general_configuration.read() };
+        let general_configuration = self.inner.general_configuration.read();
         general_configuration.enable_config()
     }
 
@@ -439,10 +439,62 @@ impl Hpet {
         if index >= self.timer_count {
             return None;
         }
-        let mmio_base_address = self.inner as usize;
+        let mmio_base_address = self.inner as *const _ as usize;
 
         let timer_address = mmio_base_address + 0x100 + (0x20 * index) as usize;
-        Some(HpetTimer::new(timer_address as *mut HpetTimerRegister))
+        unsafe {
+            // Safety: Technically unsound. We need to prevent the user from borrowing the same HpetTimer twice.
+            Some(HpetTimer::new(timer_address as *mut HpetTimerRegister))
+        }
+    }
+}
+
+impl timer::TimerDriver for Hpet {
+    /// Function in charge of setting up a new one shot timer.
+    fn set_oneshot_timer(&mut self, interval: u64) {
+        let mut main_timer = self.get_timer(0).expect("HPET main timer isn't present! THIS SHOULDN'T HAPPEN BY SPEC");
+
+        main_timer.disable_interrupt();
+
+        // IO-APIC expects edge triggering by default.
+        main_timer.set_edge_trigger();
+        main_timer.set_one_shot_mode();
+        main_timer.enable_interrupt();
+
+        // TODO: Use IRQ2 for HPET.
+        // BODY: Idealy, HPET should be using IRQ2 (which seems to be generally
+        // BODY: wired properly). Unfortunately, qemu has an unfortunate bug where
+        // BODY: interrupts for IRQ2 gets ignored.
+        // BODY: 
+        // BODY: As a workaround, we currently use IRQ16 as the timer IRQ. This is
+        // BODY: not very portable - but it'll do until we have a proper IRQ
+        // BODY: allocation scheme.
+        // BODY: 
+        // BODY: Upstream bug: https://bugs.launchpad.net/qemu/+bug/1834051
+        // Route the timer to the IRQ 16. IRQ 2 is broken, and IRQ 0 is not
+        // supported.
+        main_timer.set_interrupt_route(16);
+
+        main_timer.set_comparator_value(interval);
+        crate::i386::interrupt::unmask(16);
+    }
+
+    /// Return the target tick to wait on.
+    fn get_target_ticks(&self, ticks: u64) -> u64 {
+        self.get_main_counter_value() + ticks
+    }
+
+    fn is_after_or_equal_target_ticks(&self, target_ticks: u64) -> bool {
+        self.get_main_counter_value() >= target_ticks
+    }
+
+    /// Convert the given nanoseconds to timer ticks.
+    #[inline]
+    fn convert_ns_to_ticks(&self, ns: u64) -> u64 {
+        let minmial_tick_value = Self::PRECISION_FS / u64::from(self.get_period());
+        let computed_ticks_value = (ns * 1_000_000) / u64::from(self.get_period());
+
+        core::cmp::max(minmial_tick_value, computed_ticks_value)
     }
 }
 
@@ -451,7 +503,15 @@ assert_eq_size!(HpetRegister, [u8; 0x100]);
 /// The instance of the HPET device we are using.
 static mut HPET_INSTANCE: Option<Hpet> = None;
 
+/// Stores the instance of Sunrise's timer driver.
+pub static TIMER_DRIVER: Once<SpinLockIRQ<Hpet>> = Once::new();
+
 /// Try to initialize the HPET in legacy mode.
+///
+/// # Safety
+///
+/// Should only be called once. The Hpet registers should not be aliased - we take
+/// ownership of them.
 pub unsafe fn init(hpet: &acpi::Hpet) -> bool {
     let physical_mem = PhysicalMemRegion::on_fixed_mmio(
         PhysicalAddress(hpet.base_address.address as usize),
@@ -463,7 +523,7 @@ pub unsafe fn init(hpet: &acpi::Hpet) -> bool {
         MappingAccessRights::READABLE | MappingAccessRights::WRITABLE,
     );
     let hpet_mmio = virtual_address.addr() as *mut HpetRegister;
-    let hpet_instance = Hpet::new(hpet_mmio);
+    let mut hpet_instance = Hpet::new(hpet_mmio);
 
     // First disable the hpet if it's running.
     if hpet_instance.is_enabled() {
@@ -471,65 +531,13 @@ pub unsafe fn init(hpet: &acpi::Hpet) -> bool {
         hpet_instance.set_main_counter_value(0);
     }
 
-    // We don't need the HPET has it's useless for us.
-    if !hpet_instance.has_legacy_mapping() {
-        paging::kernel_memory::get_kernel_memory().unmap(virtual_address, PAGE_SIZE);
-        return false;
-    }
-
-    let main_timer_opt = hpet_instance.get_timer(0);
-
-    if main_timer_opt.is_none() {
-        paging::kernel_memory::get_kernel_memory().unmap(virtual_address, PAGE_SIZE);
-        return false;
-    }
-
-    let main_timer = main_timer_opt.unwrap();
-
-    // The timer must support periodic interrupt otherwise we cannot use it!
-    if !main_timer.support_periodic_interrupt() {
-        paging::kernel_memory::get_kernel_memory().unmap(virtual_address, PAGE_SIZE);
-        return false;
-    }
-
-    // Set the tick rate in femtoseconds
-    // Kernel needs an update frequency of 1 milliseconds.
-    // TODO: Switch to a lower update frequency in HPET
-    // BODY: We will maybe prefer to have a better resolution for kernel time.
-    // BODY: For that to be possible, we need to take care of the sleep_thread logic in userland first (sleep_thread(0) shouldn't be used).
-
-    let irq_period_ns = 1 * 1_000_000;
-    let irq_period_fs = irq_period_ns * 1_000_000;
-    info!("HPET frequency: {} Hz", hpet_instance.get_frequency());
-    info!("HPET IRQ period: {} fs", irq_period_fs);
-
-    let irq_period_tick = irq_period_fs / u64::from(hpet_instance.get_period());
-
-    // IO-APIC expects edge triggering by default.
-    main_timer.set_edge_trigger();
-    main_timer.set_periodic_mode();
-    main_timer.enable_interrupt();
-    main_timer.set_accumulator_value(irq_period_tick);
-    main_timer.set_comparator_value(irq_period_tick);
-    // TODO: Use IRQ2 for HPET.
-    // BODY: Idealy, HPET should be using IRQ2 (which seems to be generally
-    // BODY: wired properly). Unfortunately, qemu has an unfortunate bug where
-    // BODY: interrupts for IRQ2 gets ignored.
-    // BODY: 
-    // BODY: As a workaround, we currently use IRQ16 as the timer IRQ. This is
-    // BODY: not very portable - but it'll do until we have a proper IRQ
-    // BODY: allocation scheme.
-    // BODY: 
-    // BODY: Upstream bug: https://bugs.launchpad.net/qemu/+bug/1834051
-    // Route the timer to the IRQ 16. IRQ 2 is broken, and IRQ 0 is not
-    // supported.
-    main_timer.set_interrupt_route(16);
-
     // Clear the interrupt state
     hpet_instance.enable();
 
-    timer::set_kernel_timer_info(16, hpet_instance.get_frequency(), irq_period_ns);
+    // Set the global instance
+    TIMER_DRIVER.call_once(|| {
+        SpinLockIRQ::new(hpet_instance)
+    });
 
-    HPET_INSTANCE = Some(hpet_instance);
     true
 }

--- a/kernel/src/sync/spin_lock_irq.rs
+++ b/kernel/src/sync/spin_lock_irq.rs
@@ -60,6 +60,7 @@ pub unsafe fn permanently_disable_interrupts() {
 // BODY: solve the problem, but the scheduler would be unable to consume such
 // BODY: locks. Maybe we could have an unsafe "scheduler_relock" function that
 // BODY: may only be called from the scheduler?
+#[derive(Default)]
 pub struct SpinLockIRQ<T: ?Sized> {
     /// SpinLock we wrap.
     internal: SpinLock<T>

--- a/kernel/src/syscalls.rs
+++ b/kernel/src/syscalls.rs
@@ -191,7 +191,7 @@ pub fn wait_synchronization(handles_ptr: UserSpacePtr<[u32]>, timeout_ns: usize)
 
     // Add a waitable for the timeout.
     let timeout_waitable = if timeout_ns != usize::max_value() && timeout_ns != 0 {
-        Some(timer::wait_ns(timeout_ns))
+        Some(timer::wait_ns(timeout_ns as u64))
     } else {
         None
     };
@@ -435,7 +435,7 @@ pub fn sleep_thread(nanos: usize) -> Result<(), UserspaceError> {
         scheduler::schedule();
         Ok(())
     } else {
-        event::wait(Some(&timer::wait_ns(nanos) as &dyn Waitable)).map(|_| ())
+        event::wait(Some(&timer::wait_ns(nanos as u64) as &dyn Waitable)).map(|_| ())
     }
 }
 

--- a/kernel/src/timer.rs
+++ b/kernel/src/timer.rs
@@ -1,44 +1,78 @@
 //! The core timing of Sunrise.
 
-use core::sync::atomic::{AtomicUsize, Ordering};
+use super::event::Waitable;
+use crate::sync::{Mutex, SpinLockIRQ};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use crate::process::ThreadStruct;
 
-use super::event;
-use super::event::{IRQEvent, Waitable};
-use super::sync::Once;
-use super::utils::div_ceil;
+/// Trait representing the implementation of the main timer used by the kernel.
+pub trait TimerDriver {
+    /// Function in charge of setting up a new one shot timer.
+    fn set_oneshot_timer(&mut self, interval: u64);
 
-/// This represent the information to derive all internal timing in Sunrise.
-struct KernelTimerInfo {
-    /// The frequency of the oscillator used as primary source of this timer, when not divided, in Hertz.
+    /// Return the target tick to wait on.
+    fn get_target_ticks(&self, ticks: u64) -> u64;
+
+    /// Check if we are equal or past the given target ticks.
     ///
-    /// The value here is only informative, you should use `.irq_periode_ns`.
-    oscillator_frequency: u64,
+    /// # Note:
+    /// - The driver *must* asure that the ticks are monotonic.
+    fn is_after_or_equal_target_ticks(&self, target_ticks: u64) -> bool;
 
-    /// The IRQ period used on this timer in nanoseconds.
-    pub irq_period_ns: u64,
-
-    /// The IRQ number that the timer use.
-    pub irq_number: u8,
+    /// Convert the given nanoseconds to timer ticks.
+    fn convert_ns_to_ticks(&self, ns: u64) -> u64;
 }
 
-/// Stores the information needed for Sunrise's internal timing.
-static KERNEL_TIMER_INFO: Once<KernelTimerInfo> = Once::new();
+use core::cmp::Ordering as CmpOrdering;
 
-/// Set the information required for Sunrise timer to work.
-/// 
-/// # Panics
-///
-/// Panics if the timer info has already been initialized.
-pub fn set_kernel_timer_info(irq_number: u8, oscillator_frequency: u64, irq_period_ns: u64) {
-    assert!(KERNEL_TIMER_INFO.r#try().is_none(), "Kernel Timer Info is already initialized!");
-    KERNEL_TIMER_INFO.call_once(|| {
-        KernelTimerInfo {
-            irq_number,
-            oscillator_frequency,
-            irq_period_ns
+/// Timer state.
+struct TimerState {
+    /// The waiting thread.
+    target_waiter: Arc<ThreadStruct>,
+
+    /// Target ticks to be wakup at.
+    target_ticks: u64
+}
+
+impl TimerState {
+    /// Create a new TimerState with a given target ticks.
+    ///
+    /// # Note:
+    /// - The TimerState will be linked to the current thread.
+    pub fn new(target_ticks: u64) -> Self {
+        TimerState {
+            target_waiter: crate::scheduler::get_current_thread(),
+            target_ticks
         }
-    });
+    }
 }
+
+impl Ord for TimerState {
+    fn cmp(&self, other: &Self) -> CmpOrdering {
+        self.target_ticks.cmp(&other.target_ticks)
+    }
+}
+
+impl PartialOrd for TimerState {
+    fn partial_cmp(&self, other: &Self) -> Option<CmpOrdering> {
+        self.target_ticks.partial_cmp(&other.target_ticks)
+    }
+}
+
+impl PartialEq for TimerState {
+    fn eq(&self, other: &Self) -> bool {
+        self.target_ticks == other.target_ticks
+    }
+}
+
+impl Eq for TimerState {}
+
+/// Global state for all threads currently sleeping.
+static TIMER_STATES: SpinLockIRQ<Vec<TimerState>> = SpinLockIRQ::new(Vec::new());
+
+#[cfg(any(target_arch="x86", rustdoc))]
+use crate::devices::hpet::TIMER_DRIVER;
 
 /// Returns a stream of event that trigger every `ns` amount of nanoseconds.
 /// 
@@ -46,58 +80,112 @@ pub fn set_kernel_timer_info(irq_number: u8, oscillator_frequency: u64, irq_peri
 /// 
 /// - If the timer resolution cannot handle it, this is not going to be accurate.
 /// - Minimal resolution for HPET (10Mhz) / HPET QEMU (100Mhz): 100ns / 10ns
-/// - Minimal resolution for PIC (~1Mhz): 10ms
 pub fn wait_ns(ns: usize) -> impl Waitable {
-    let timer_info = KERNEL_TIMER_INFO.r#try().expect("Kernel Timer Info is not initialized!");
-    IRQTimer::new(ns, timer_info.irq_number, timer_info.irq_period_ns)
+    TimerEvent::new(ns as u64)
 }
 
 #[derive(Debug)]
-/// A stream of event that trigger every `ns` amount of nanoseconds, by counting interruptions.
-pub struct IRQTimer {
-    /// Approximation of number of ns spent between triggers.
-    every_ns: usize,
-    /// IRQ event period in nanoseconds.
-    irq_period_ns: u64,
-    /// The IRQ that we wait on.
-    parent_event: IRQEvent,
-    /// The reset value of ``.countdown_value``.
-    reset_value: usize,
-    /// Number of IRQ triggers to wait for. Derived from `.every_ns`. This is the exact time amout that is used.
-    countdown_value: AtomicUsize
+/// A stream of event that trigger after `ns` amount of nanoseconds.
+pub struct TimerEvent {
+    /// The count of ticks to wait to atain the expected amount of nanoseconds.
+    ticks: u64,
+
+    /// The target ticks value that we are currently waiting on.
+    target_ticks: Mutex<u64>
 }
 
-impl IRQTimer {
-    /// Create a new IRQ timer instance from the time to wait (in ns), the irq number and irq event period (in ns).
-    pub fn new(ns: usize, irq: u8, irq_period_ns: u64) -> Self {
-        let mut reset_value = div_ceil(ns as u64, irq_period_ns) as usize;
-        if reset_value == 0 {
-            reset_value = 1;
-        }
+impl TimerEvent {
+    /// Create a new timer event instance from the time to wait (in ns).
+    pub fn new(ns: u64) -> Self {
+        let timer_driver = TIMER_DRIVER.r#try().expect("Timer driver is not initialized!").lock();
+        let ticks = timer_driver.convert_ns_to_ticks(ns);
 
-        IRQTimer {
-            every_ns: ns,
-            irq_period_ns,
-            parent_event: event::wait_event(irq),
-            reset_value,
-            countdown_value: AtomicUsize::new(0)
+        TimerEvent {
+            ticks,
+            target_ticks: Mutex::new(timer_driver.get_target_ticks(ticks))
         }
+    }
+
+    /// Get the target ticks
+    pub fn get_target_ticks(&self) -> u64 {
+        *self.target_ticks.lock()
     }
 }
 
-impl Waitable for IRQTimer {
+impl Waitable for TimerEvent {
     fn register(&self) {
-        self.parent_event.register()
+        {
+            let target_ticks = self.target_ticks.lock();
+            assert!(*target_ticks != 0, "TimerEvent already registered!");
+        }
+
+        register_timer_event(self);
     }
 
     fn is_signaled(&self) -> bool {
-        // First, reset the spins if necessary
-        self.countdown_value.compare_and_swap(0, self.reset_value, Ordering::SeqCst);
+        let mut target_ticks = self.target_ticks.lock();
+        let result = {
+            let timer_driver = TIMER_DRIVER.r#try().expect("Timer driver is not initialized!").lock();
+            timer_driver.is_after_or_equal_target_ticks(*target_ticks)
+        };
 
-        // Then, check if it's us.
-        self.parent_event.is_signaled()
-            // Then, check if we need more spins.
-            && self.countdown_value.fetch_sub(1, Ordering::SeqCst) == 1
+        if result {
+            *target_ticks = 0;
+        }
+
+        result
     }
 }
 
+/// Register a timer waiter.
+fn register_timer_event(event: &TimerEvent) {
+    let mut states = TIMER_STATES.lock();
+    let target_ticks = event.get_target_ticks();
+
+    let insert_position = states.iter().position(|x| x.target_ticks >= target_ticks);
+    let need_oneshot_setup = insert_position.is_none() || insert_position == Some(0);
+
+    states.insert(insert_position.unwrap_or(0), TimerState::new(target_ticks));
+
+    // If no oneshot was setup or this timer is lower than the current in usage, we need to do the oneshot setup again.
+    if need_oneshot_setup {
+        let next_oneshot = states.get(0);
+
+        // Setup next oneshot if present.
+        if let Some(next_oneshot) = next_oneshot {
+            let mut timer_driver = TIMER_DRIVER.r#try().expect("Timer driver is not initialized!").lock();
+            timer_driver.set_oneshot_timer(next_oneshot.target_ticks);
+        }
+    }
+}
+
+/// Signal the scheduler and waiters that a oneshot has ended.
+///
+/// #Note:
+///
+/// - This must be called by the timer IRQ handler.
+pub fn wakeup_waiters() {
+    // TODO: mask interruptions?
+    let mut timer_driver = TIMER_DRIVER.r#try().expect("Timer driver is not initialized!").lock();
+
+    let mut states = TIMER_STATES.lock();
+
+    // Get all threads to wake up.
+    let target_index: Vec<usize> = states.iter().enumerate().filter(|x| timer_driver.is_after_or_equal_target_ticks(x.1.target_ticks)).map(|x| x.0).collect();
+
+    // Remove threads from the state Vec and schedule them.
+    for _ in target_index {
+        // As the vec is always sorted, we just remove the first element every time
+        let state = states.remove(0);
+        crate::scheduler::add_to_schedule_queue(state.target_waiter);
+    }
+
+    let next_oneshot = states.get(0);
+
+    // Setup next oneshot if present.
+    if let Some(next_oneshot) = next_oneshot {
+        timer_driver.set_oneshot_timer(next_oneshot.target_ticks);
+    }
+
+    // TODO: unmask interruptions?
+}

--- a/kernel/src/timer.rs
+++ b/kernel/src/timer.rs
@@ -80,8 +80,8 @@ use crate::devices::hpet::TIMER_DRIVER;
 /// 
 /// - If the timer resolution cannot handle it, this is not going to be accurate.
 /// - Minimal resolution for HPET (10Mhz) / HPET QEMU (100Mhz): 100ns / 10ns
-pub fn wait_ns(ns: usize) -> impl Waitable {
-    TimerEvent::new(ns as u64)
+pub fn wait_ns(ns: u64) -> impl Waitable {
+    TimerEvent::new(ns)
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This PR improve the timer implementation that we currently have by switching to a oneshot approach.

Also remove PIT support and improve HPET driver safety.