### PR TITLE
Implement Thread::join

### DIFF
--- a/kernel/src/i386/interrupt_service_routines.rs
+++ b/kernel/src/i386/interrupt_service_routines.rs
@@ -56,7 +56,7 @@ use sunrise_libkern::{nr, SYSCALL_NAMES};
 /// As this function will be the last that will be called by a thread before dying,
 /// caller must make sure all of its scope variables are ok to be leaked.
 pub fn check_thread_killed() {
-    if scheduler::get_current_thread().state.load(Ordering::SeqCst) == ThreadState::Killed {
+    if scheduler::get_current_thread().state.load(Ordering::SeqCst) == ThreadState::Exited {
         let lock = SpinLockIRQ::new(());
         loop { // in case of spurious wakeups
             let _ = scheduler::unschedule(&lock, lock.lock());

--- a/kernel/src/i386/interrupt_service_routines.rs
+++ b/kernel/src/i386/interrupt_service_routines.rs
@@ -56,7 +56,7 @@ use sunrise_libkern::{nr, SYSCALL_NAMES};
 /// As this function will be the last that will be called by a thread before dying,
 /// caller must make sure all of its scope variables are ok to be leaked.
 pub fn check_thread_killed() {
-    if scheduler::get_current_thread().state.load(Ordering::SeqCst) == ThreadState::Exited {
+    if scheduler::get_current_thread().state.load(Ordering::SeqCst) == ThreadState::TerminationPending {
         let lock = SpinLockIRQ::new(());
         loop { // in case of spurious wakeups
             let _ = scheduler::unschedule(&lock, lock.lock());

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -211,7 +211,7 @@ pub enum Handle {
     SharedMemory(Arc<SpinRwLock<Vec<PhysicalMemRegion>>>),
 }
 
-/// The underlying shared object of a [ThreadStateReadableEvent].
+/// The underlying shared object of a [Weak<ThreadStrct>].
 #[derive(Debug)]
 struct ThreadStateEvent {
     /// List of threads waiting on this thread to exit. When this thread exit, all

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -233,7 +233,7 @@ impl ThreadStateEvent {
 impl Waitable for Weak<ThreadStruct> {
     fn is_signaled(&self) -> bool {
         if let Some(thread) = self.upgrade() {
-            return thread.state.load(Ordering::Relaxed) == ThreadState::TerminationPending;
+            return thread.state.load(Ordering::SeqCst) == ThreadState::TerminationPending;
         }
 
         // Cannot upgrade to Arc? The thread is dead, so it totally have exited!

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -164,7 +164,7 @@ pub struct ThreadStruct {
     /// Thread state event
     ///
     /// This is used when signaling that this thread as exited.
-    state_event: Arc<ThreadStateEvent>
+    state_event: ThreadStateEvent
 }
 
 /// A handle to a userspace-accessible resource.
@@ -693,9 +693,9 @@ impl ThreadStruct {
                 tls_region: tls,
                 tls_elf: SpinLock::new(VirtualAddress(0x00000000)),
                 userspace_hwcontext: SpinLock::new(UserspaceHardwareContext::default()),
-                state_event: Arc::new(ThreadStateEvent {
+                state_event: ThreadStateEvent {
                     waiting_threads: SpinLock::new(Vec::new())
-                }),
+                },
             }
         );
 
@@ -792,9 +792,9 @@ impl ThreadStruct {
                 tls_region: tls,
                 tls_elf: SpinLock::new(VirtualAddress(0x00000000)),
                 userspace_hwcontext: SpinLock::new(UserspaceHardwareContext::default()),
-                state_event: Arc::new(ThreadStateEvent {
+                state_event: ThreadStateEvent {
                     waiting_threads: SpinLock::new(Vec::new())
-                }),
+                },
             }
         );
 

--- a/kernel/src/scheduler.rs
+++ b/kernel/src/scheduler.rs
@@ -122,7 +122,7 @@ pub fn add_to_schedule_queue(thread: Arc<ThreadStruct>) {
         Err(v) => v
     };
 
-    assert!(oldstate == ThreadState::Stopped || oldstate == ThreadState::Killed,
+    assert!(oldstate == ThreadState::Stopped || oldstate == ThreadState::Exited,
                "Process added to schedule queue was not stopped : {:?}", oldstate);
 
     queue_lock.push(thread)
@@ -167,13 +167,13 @@ where
             Ok(v) => v,
             Err(v) => v
         };
-        assert!(old == ThreadState::Killed || old == ThreadState::Running, "Old was in invalid state {:?} before unscheduling", old);
+        assert!(old == ThreadState::Exited || old == ThreadState::Running, "Old was in invalid state {:?} before unscheduling", old);
         mem::drop(guard)
     }
 
     let guard = internal_schedule(lock, true);
 
-    if get_current_thread().state.load(Ordering::SeqCst) == ThreadState::Killed {
+    if get_current_thread().state.load(Ordering::SeqCst) == ThreadState::Exited {
         Err(UserspaceError::Canceled)
     } else {
         Ok(guard)

--- a/kernel/src/scheduler.rs
+++ b/kernel/src/scheduler.rs
@@ -116,13 +116,13 @@ pub fn add_to_schedule_queue(thread: Arc<ThreadStruct>) {
         return;
     }
 
-    let oldstate = thread.state.compare_exchange(ThreadState::Stopped, ThreadState::Scheduled, Ordering::SeqCst, Ordering::SeqCst);
+    let oldstate = thread.state.compare_exchange(ThreadState::Paused, ThreadState::Scheduled, Ordering::SeqCst, Ordering::SeqCst);
     let oldstate = match oldstate {
         Ok(v) => v,
         Err(v) => v
     };
 
-    assert!(oldstate == ThreadState::Stopped || oldstate == ThreadState::Exited,
+    assert!(oldstate == ThreadState::Paused || oldstate == ThreadState::TerminationPending,
                "Process added to schedule queue was not stopped : {:?}", oldstate);
 
     queue_lock.push(thread)
@@ -132,7 +132,7 @@ pub fn add_to_schedule_queue(thread: Arc<ThreadStruct>) {
 pub fn is_in_schedule_queue(queue: &SpinLockIRQGuard<'_, Vec<Arc<ThreadStruct>>>,
                             thread: &Arc<ThreadStruct>) -> bool {
     CURRENT_THREAD.borrow().iter().filter(|v| {
-        v.state.load(Ordering::SeqCst) != ThreadState::Stopped
+        v.state.load(Ordering::SeqCst) != ThreadState::Paused
     }).chain(queue.iter()).any(|elem| Arc::ptr_eq(thread, elem))
 }
 
@@ -162,18 +162,18 @@ where
 {
     {
         let thread = get_current_thread();
-        let old = thread.state.compare_exchange(ThreadState::Running, ThreadState::Stopped, Ordering::SeqCst, Ordering::SeqCst);
+        let old = thread.state.compare_exchange(ThreadState::Running, ThreadState::Paused, Ordering::SeqCst, Ordering::SeqCst);
         let old = match old {
             Ok(v) => v,
             Err(v) => v
         };
-        assert!(old == ThreadState::Exited || old == ThreadState::Running, "Old was in invalid state {:?} before unscheduling", old);
+        assert!(old == ThreadState::TerminationPending || old == ThreadState::Running, "Old was in invalid state {:?} before unscheduling", old);
         mem::drop(guard)
     }
 
     let guard = internal_schedule(lock, true);
 
-    if get_current_thread().state.load(Ordering::SeqCst) == ThreadState::Exited {
+    if get_current_thread().state.load(Ordering::SeqCst) == ThreadState::TerminationPending {
         Err(UserspaceError::Canceled)
     } else {
         Ok(guard)

--- a/kernel/src/syscalls.rs
+++ b/kernel/src/syscalls.rs
@@ -272,7 +272,7 @@ pub fn connect_to_port(handle: u32) -> Result<usize, UserspaceError> {
 
 /// Kills our own thread.
 pub fn exit_thread() -> Result<(), UserspaceError> {
-    ThreadStruct::kill(get_current_thread());
+    ThreadStruct::exit(get_current_thread());
     Ok(())
 }
 

--- a/libuser/src/threads.rs
+++ b/libuser/src/threads.rs
@@ -258,6 +258,12 @@ impl Thread {
         .map_err(|v| v.into())
     }
 
+    /// Wait for the thread to exit.
+    pub fn join(&self) -> Result<(), Error> {
+        let thread_handle = (*self.0).thread_handle.r#try().unwrap().0.as_ref();
+        syscalls::wait_synchronization(&[thread_handle], None).map_err(|v| v.into()).map(|_| ())
+    }
+
     /// Allocates resources for a thread. To start it, call [`start`].
     ///
     /// Allocates the stack, sets up the context and TLS, and calls `svcCreateThread`.

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -528,7 +528,7 @@ fn test_threads(terminal: Terminal) -> Terminal {
 
     match Arc::try_unwrap(terminal) {
         Ok(terminal) => terminal.into_inner(),
-        Err(_) => panic!("Cannot Arc::try_unwrap after the exit of thread b, this is unexpected!")
+        _ => panic!("Cannot Arc::try_unwrap after the exit of thread b, this is unexpected!")
     }
 }
 


### PR DESCRIPTION
This allows to wait for a thread to be in an exit state.

Also rearrange ThreadState to be closer to Horizon states.