### PR TITLE
Implement loader interface and waiting on process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,8 @@ dependencies = [
 name = "sunrise-loader"
 version = "0.1.0"
 dependencies = [
+ "futures-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libkern 0.1.0",
  "sunrise-libuser 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ name = "lazy_static"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "spin 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -400,7 +400,7 @@ source = "git+https://github.com/sunriseos/libfat.git#2fc179154b3e7861a93f5f5b4a
 dependencies = [
  "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage_device 1.0.0 (git+https://github.com/Sunriseos/storage_device.git)",
 ]
 
@@ -414,7 +414,7 @@ name = "linked_list_allocator"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "spin 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -625,7 +625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "spin"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -679,7 +679,7 @@ dependencies = [
  "futures-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libuser 0.1.0",
  "sunrise-libutils 0.1.0",
@@ -695,7 +695,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "multiboot2 0.7.1 (git+https://github.com/sunriseos/multiboot2-elf64.git)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libutils 0.1.0",
  "xmas-elf 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -742,7 +742,7 @@ dependencies = [
  "plain 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libkern 0.1.0",
  "sunrise-libutils 0.1.0",
@@ -759,7 +759,7 @@ dependencies = [
  "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libuser 0.1.0",
  "sunrise-libutils 0.1.0",
 ]
@@ -803,7 +803,7 @@ dependencies = [
  "libm 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked_list_allocator 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libkern 0.1.0",
  "sunrise-libutils 0.1.0",
  "swipc-gen 0.1.0",
@@ -823,9 +823,11 @@ dependencies = [
 name = "sunrise-loader"
 version = "0.1.0"
 dependencies = [
+ "core-futures-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libkern 0.1.0",
  "sunrise-libuser 0.1.0",
  "sunrise-libutils 0.1.0",
@@ -842,7 +844,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libuser 0.1.0",
 ]
 
@@ -854,7 +856,7 @@ dependencies = [
  "hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libuser 0.1.0",
 ]
 
@@ -867,7 +869,7 @@ dependencies = [
  "futures-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libtimezone 0.1.0",
  "sunrise-libuser 0.1.0",
  "sunrise-libutils 0.1.0",
@@ -880,7 +882,7 @@ dependencies = [
  "futures-preview 0.3.0-alpha.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libuser 0.1.0",
  "sunrise-libutils 0.1.0",
 ]
@@ -891,7 +893,7 @@ version = "0.1.0"
 dependencies = [
  "bstr 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sunrise-libuser 0.1.0",
 ]
 
@@ -1110,7 +1112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum spin 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ceac490aa12c567115b40b7b7fceca03a6c9d53d5defea066123debc83c5dc1f"
-"checksum spin 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbdb51a221842709c2dd65b62ad4b78289fc3e706a02c17a26104528b6aa7837"
+"checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum static_assertions 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4f8de36da215253eb5f24020bfaa0646613b48bf7ebe36cdfa37c3b3b33b241"
 "checksum storage_device 1.0.0 (git+https://github.com/Sunriseos/storage_device.git)" = "<none>"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -170,11 +170,11 @@ mkisofs-rs external/grub/isofiles isofiles -o os.iso -b boot/grub/i386-pc/eltori
 description = "Creates an empty disk image."
 script = [
 '''
-mkdir -p external/filesystem/disk_template/bin/0200000000000000/flags
-cp target/i386-unknown-sunrise-user/$PROFILE_NAME/sunrise-wall-clock     external/filesystem/disk_template/bin/0200000000000000/main
+mkdir -p external/filesystem/disk_template/bin/wall-clock/flags
+cp target/i386-unknown-sunrise-user/$PROFILE_NAME/sunrise-wall-clock     external/filesystem/disk_template/bin/wall-clock/main
 
 # TODO: https://github.com/sagiegurari/shell2batch/issues/9
-touch external/filesystem/disk_template/bin/0200000000000000/flags/boot.flag
+#touch external/filesystem/disk_template/bin/wall-clock/flags/boot.flag
 cargo run --manifest-path disk-initializer/Cargo.toml -- DISK.img 52428800 external/filesystem/disk_template/
 '''
 ]

--- a/ipcdefs/loader.id
+++ b/ipcdefs/loader.id
@@ -1,3 +1,4 @@
 interface sunrise_libuser::ldr::ILoaderInterface is ldr:shel {
-    [0] launch_title(array<u8, 9> title_name, array<u8, 9> args);
+    [0] launch_title(array<u8, 9> title_name, array<u8, 9> args) -> u64 pid;
+    [1] wait(u64 pid) -> u32 exit_status;
 }

--- a/ipcdefs/loader.id
+++ b/ipcdefs/loader.id
@@ -1,0 +1,3 @@
+interface sunrise_libuser::ldr::ILoaderInterface is ldr:shel {
+    [0] launch_title(array<u8, 9> title_name, array<u8, 9> args);
+}

--- a/ipcdefs/loader.id
+++ b/ipcdefs/loader.id
@@ -1,4 +1,10 @@
+# A mishmash of Nintendo's loader and pm in a single disgusting service.
+#
+# Responsible for creating, loading, starting and waiting on processes.
 interface sunrise_libuser::ldr::ILoaderInterface is ldr:shel {
+    # Create, load and start the process `title_name` with the given args.
+    # Returns the process' pid.
     [0] launch_title(array<u8, 9> title_name, array<u8, 9> args) -> u64 pid;
+    # Wait for the process with the given pid, returning the exit status.
     [1] wait(u64 pid) -> u32 exit_status;
 }

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -43,8 +43,8 @@ pub enum KernelError {
     ProcessKilled {
         backtrace: Backtrace,
     },
-    #[fail(display = "Thread was already started")]
-    ThreadAlreadyStarted {
+    #[fail(display = "Handle was in invalid state for this operation.")]
+    InvalidState {
         backtrace: Backtrace,
     },
     #[fail(display = "Invalid combination of values passed.")]
@@ -90,7 +90,7 @@ impl From<KernelError> for UserspaceError {
         match err {
             KernelError::PhysicalMemoryExhaustion { .. } => UserspaceError::MemoryFull,
             KernelError::VirtualMemoryExhaustion { .. } => UserspaceError::MemoryFull,
-            KernelError::ThreadAlreadyStarted { .. } => UserspaceError::ProcessAlreadyStarted,
+            KernelError::InvalidState { .. } => UserspaceError::InvalidState,
             KernelError::InvalidAddress { .. } => UserspaceError::InvalidAddress,
             KernelError::InvalidSize { .. } => UserspaceError::InvalidSize,
             KernelError::InvalidCombination { .. } => UserspaceError::InvalidCombination,

--- a/kernel/src/event.rs
+++ b/kernel/src/event.rs
@@ -168,7 +168,7 @@ impl ReadableEvent {
     ///   - The event wasn't signaled.
     pub fn clear_signal(&self) -> Result<(), KernelError> {
         let oldstate = self.parent.state.swap(false, Ordering::SeqCst);
-        if oldstate == false {
+        if !oldstate {
             return Err(KernelError::InvalidState { backtrace: Backtrace::new() })
         }
         Ok(())
@@ -210,7 +210,7 @@ impl WritableEvent {
     ///   - The event wasn't signaled.
     pub fn clear_signal(&self) -> Result<(), KernelError> {
         let oldstate = self.parent.state.swap(false, Ordering::SeqCst);
-        if oldstate == false {
+        if !oldstate {
             return Err(KernelError::InvalidState { backtrace: Backtrace::new() })
         }
         Ok(())

--- a/kernel/src/i386/interrupt_service_routines.rs
+++ b/kernel/src/i386/interrupt_service_routines.rs
@@ -943,6 +943,7 @@ fn syscall_interrupt_dispatcher(_exception_name: &'static str, hwcontext: &mut U
         (true, nr::UnmapProcessMemory) => hwcontext.apply0(unmap_process_memory(x0 as _, x1 as _, x2 as _, x3 as _)),
         (true, nr::CreateProcess) => hwcontext.apply1(create_process(UserSpacePtr(x0 as _), UserSpacePtr::from_raw_parts(x1 as _, x2 * 4))),
         (true, nr::StartProcess) => hwcontext.apply0(start_process(x0 as _, x1 as _, x2 as _, x3 as _)),
+        (true, nr::GetProcessInfo) => hwcontext.apply1(get_process_info(x0 as _, x1 as _)),
 
         // sunrise extensions
         (true, nr::MapFramebuffer) => hwcontext.apply4(map_framebuffer()),

--- a/kernel/src/i386/interrupt_service_routines.rs
+++ b/kernel/src/i386/interrupt_service_routines.rs
@@ -928,6 +928,7 @@ fn syscall_interrupt_dispatcher(_exception_name: &'static str, hwcontext: &mut U
         (true, nr::WaitSynchronization) => hwcontext.apply1(wait_synchronization(UserSpacePtr::from_raw_parts(x0 as _, x1), x2)),
         (true, nr::ConnectToNamedPort) => hwcontext.apply1(connect_to_named_port(UserSpacePtr(x0 as _))),
         (true, nr::SendSyncRequestWithUserBuffer) => hwcontext.apply0(send_sync_request_with_user_buffer(UserSpacePtrMut::from_raw_parts_mut(x0 as _, x1), x2 as _)),
+        (true, nr::GetProcessId) => hwcontext.apply1(get_process_id(x0 as _)),
         (true, nr::OutputDebugString) => hwcontext.apply0(output_debug_string(UserSpacePtr::from_raw_parts(x0 as _, x1), x2, UserSpacePtr::from_raw_parts(x3 as _, x4))),
         (true, nr::CreateSession) => hwcontext.apply2(create_session(x0 != 0, x1 as _)),
         (true, nr::AcceptSession) => hwcontext.apply1(accept_session(x0 as _)),

--- a/kernel/src/i386/interrupt_service_routines.rs
+++ b/kernel/src/i386/interrupt_service_routines.rs
@@ -924,6 +924,7 @@ fn syscall_interrupt_dispatcher(_exception_name: &'static str, hwcontext: &mut U
         (true, nr::MapSharedMemory) => hwcontext.apply0(map_shared_memory(x0 as _, x1 as _, x2 as _, x3 as _)),
         (true, nr::UnmapSharedMemory) => hwcontext.apply0(unmap_shared_memory(x0 as _, x1 as _, x2 as _)),
         (true, nr::CloseHandle) => hwcontext.apply0(close_handle(x0 as _)),
+        (true, nr::ResetSignal) => hwcontext.apply0(reset_signal(x0 as _)),
         (true, nr::WaitSynchronization) => hwcontext.apply1(wait_synchronization(UserSpacePtr::from_raw_parts(x0 as _, x1), x2)),
         (true, nr::ConnectToNamedPort) => hwcontext.apply1(connect_to_named_port(UserSpacePtr(x0 as _))),
         (true, nr::SendSyncRequestWithUserBuffer) => hwcontext.apply0(send_sync_request_with_user_buffer(UserSpacePtrMut::from_raw_parts_mut(x0 as _, x1), x2 as _)),

--- a/kernel/src/i386/interrupt_service_routines.rs
+++ b/kernel/src/i386/interrupt_service_routines.rs
@@ -397,7 +397,7 @@ macro_rules! trap_gate_asm {
 ///         let thread = get_current_thread();                                       //
 ///         error!("{}, errorcode: {}, in {:#?}",                                    // handler_strategy
 ///             $exception_name, $hwcontext.errcode, thread);                        // (here: kill)
-///         ProcessStruct::kill_process(thread.process.clone());                     //
+///         ProcessStruct::kill_current_process();                                   //
 ///     }
 ///
 ///     // if we're returning to userspace, check we haven't been killed
@@ -476,7 +476,7 @@ macro_rules! generate_trap_gate_handler {
         {
             let thread = get_current_thread();
             error!("{}, errorcode: {}, in {:#?}", $exception_name, $hwcontext.errcode, thread);
-            ProcessStruct::kill_process(thread.process.clone());
+            ProcessStruct::kill_current_process();
         }
     };
 
@@ -484,7 +484,7 @@ macro_rules! generate_trap_gate_handler {
         {
             let thread = get_current_thread();
             error!("{}, in {:#?}", $exception_name, thread);
-            ProcessStruct::kill_process(thread.process.clone());
+            ProcessStruct::kill_current_process();
         }
     };
     // end handler
@@ -724,7 +724,7 @@ fn user_page_fault_handler(_exception_name: &'static str, hwcontext: &mut Usersp
 
     let thread = get_current_thread();
     error!("Page Fault accessing {:?}, exception errcode: {:?} in {:#?}", cause_address, errcode, thread);
-    ProcessStruct::kill_process(thread.process.clone());
+    ProcessStruct::kill_current_process();
 }
 
 generate_trap_gate_handler!(name: "x87 FPU floating-point error",
@@ -957,13 +957,13 @@ fn syscall_interrupt_dispatcher(_exception_name: &'static str, hwcontext: &mut U
             let curproc = get_current_process();
             error!("Process {} attempted to use unauthorized syscall {} ({:#04x}), killing",
                    curproc.name, syscall_name, syscall_nr);
-            ProcessStruct::kill_process(curproc);
+            ProcessStruct::kill_current_process();
         },
         _ => {
             let curproc = get_current_process();
             error!("Process {} attempted to use unknown syscall {} ({:#04x}), killing",
                    curproc.name, syscall_name, syscall_nr);
-            ProcessStruct::kill_process(curproc);
+            ProcessStruct::kill_current_process();
         }
     }
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -89,10 +89,9 @@ pub use crate::heap_allocator::rust_oom;
 static ALLOCATOR: heap_allocator::Allocator = heap_allocator::Allocator::new();
 
 use crate::i386::stack;
-use crate::paging::{PAGE_SIZE, MappingAccessRights};
+use crate::paging::PAGE_SIZE;
 use crate::mem::VirtualAddress;
-use crate::process::{ProcessStruct, ThreadStruct};
-use sunrise_libkern::MemoryType;
+use crate::process::ProcessStruct;
 use crate::cpu_locals::init_cpu_locals;
 use sunrise_libkern::process::*;
 

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -27,31 +27,69 @@ use crate::paging::{InactiveHierarchy, InactiveHierarchyTrait, PAGE_SIZE, Mappin
 use self::thread_local_storage::TLSManager;
 use crate::i386::interrupt_service_routines::UserspaceHardwareContext;
 use sunrise_libkern::process::ProcInfo;
-use sunrise_libkern::MemoryType;
+use sunrise_libkern::{ProcessState, MemoryType};
 
-/// The state the process is currently in.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ProcessState {
-    /// Process is freshly created with svcCreateProcess and has not yet been
-    /// started.
-    Created,
-    /// Process has been attached with a debugger before it was started.
-    CreatedAttached,
-    /// Process has been started.
-    Started,
-    /// Process has crashed.
+/// Data related to the (user-visible) state the current process is in. The
+/// maternity is stored here to ensure there is no race condition between
+/// setting the state to Exited and adding threads to the maternity.
+#[derive(Debug)]
+struct ProcessStateData {
+    /// Whether the process is currently in a signaled state. Set to true when
+    /// changing the state, and false when the user calls reset_signal(). Note
+    /// that once the Exited state is reached, the process is permanently
+    /// signaled.
+    signaled: bool,
+
+    /// The current state of the process.
+    state: ProcessState,
+
+    /// Threads waiting on this process to get signaled.
+    waiting_threads: Vec<Arc<ThreadStruct>>,
+
+    /// An array of the created but not yet started threads.
     ///
-    /// Processes will not enter this state unless they were created with EnableDebug.
-    Crashed,
-    /// Process is started and has a debugger attached.
-    StartedAttached,
-    /// Process is currently exiting.
-    Exiting,
-    /// Process is stopped.
-    Exited,
-    /// Process has been suspended.
-    DebugSuspended
+    /// When we create a thread, we return a handle to userspace containing a weak reference to the thread,
+    /// which has not been added to the schedule queue yet.
+    /// To prevent it from being dropped, we must keep at least 1 strong reference somewhere.
+    /// This is the job of the maternity. It holds references to threads that no one has for now.
+    /// When a thread is started, its only strong reference is removed from the maternity, and put
+    /// in the scheduler, which is now in charge of keeping it alive (or not).
+    ///
+    /// Note that we store in the process struct a strong reference to a thread, which itself
+    /// has a strong reference to the same process struct. This creates a cycle, and we loose
+    /// the behaviour of "a process is dropped when its last *living* thread is dropped".
+    /// The non-started threads will keep the process struct alive. This makes it possible to
+    /// pass a non-started thread handle to another process, and let it start it for us, even after
+    /// our last living thread has died.
+    ///
+    /// However, because of this, if a thread creates other threads, does not share the handles,
+    /// and dies before starting them, the process struct will be kept alive indefinitely
+    /// by those non-started threads that no one can start, and the process will stay that way
+    /// until it is explicitly stopped from outside.
+    // TODO: Use a better lock around thread_maternity.
+    // BODY: Thread maternity currently uses a SpinLock. We should ideally use a
+    // BODY: scheduling mutex there.
+    thread_maternity: Vec<Arc<ThreadStruct>>,
 }
+
+impl ProcessStateData {
+    /// Sets the state to the given new state, and signal the process, causing
+    /// any threads waiting on the process to get woken up.
+    fn set_state(&mut self, newstate: ProcessState) {
+        self.state = newstate;
+        self.signal();
+    }
+
+    /// Set the process to the signaled state, and wake up any thread waiting
+    /// on this process to get signaled.
+    fn signal(&mut self) {
+        self.signaled = true;
+        while let Some(thread) = self.waiting_threads.pop() {
+            scheduler::add_to_schedule_queue(thread);
+        }
+    }
+}
+
 
 /// The struct representing a process. There's one for every process.
 ///
@@ -84,35 +122,10 @@ pub struct ProcessStruct {
     pub capabilities:             ProcessCapabilities,
 
     /// The state the process is currently in.
-    state:                    Atomic<ProcessState>,
+    state:                    Mutex<ProcessStateData>,
 
     /// Tracks used and free allocated Thread Local Storage regions of this process.
     pub tls_manager: Mutex<TLSManager>,
-
-    /// An array of the created but not yet started threads.
-    ///
-    /// When we create a thread, we return a handle to userspace containing a weak reference to the thread,
-    /// which has not been added to the schedule queue yet.
-    /// To prevent it from being dropped, we must keep at least 1 strong reference somewhere.
-    /// This is the job of the maternity. It holds references to threads that no one has for now.
-    /// When a thread is started, its only strong reference is removed from the maternity, and put
-    /// in the scheduler, which is now in charge of keeping it alive (or not).
-    ///
-    /// Note that we store in the process struct a strong reference to a thread, which itself
-    /// has a strong reference to the same process struct. This creates a cycle, and we loose
-    /// the behaviour of "a process is dropped when its last *living* thread is dropped".
-    /// The non-started threads will keep the process struct alive. This makes it possible to
-    /// pass a non-started thread handle to another process, and let it start it for us, even after
-    /// our last living thread has died.
-    ///
-    /// However, because of this, if a thread creates other threads, does not share the handles,
-    /// and dies before starting them, the process struct will be kept alive indefinitely
-    /// by those non-started threads that no one can start, and the process will stay that way
-    /// until it is explicitly stopped from outside.
-    // TODO: Use a better lock around thread_maternity.
-    // BODY: Thread maternity currently uses a SpinLock. We should ideally use a
-    // BODY: scheduling mutex there.
-    thread_maternity: SpinLock<Vec<Arc<ThreadStruct>>>,
 }
 
 /// Next available PID.
@@ -481,11 +494,15 @@ impl ProcessStruct {
                 name: String::from_utf8_lossy(&procinfo.name).into_owned(),
                 entrypoint: VirtualAddress(procinfo.code_addr as usize),
                 pmemory,
-                state: Atomic::new(ProcessState::Created),
+                state: Mutex::new(ProcessStateData {
+                    state: ProcessState::Created,
+                    signaled: false,
+                    waiting_threads: Vec::new(),
+                    thread_maternity: Vec::new(),
+                }),
                 threads: SpinLockIRQ::new(Vec::new()),
                 phandles: SpinLockIRQ::new(HandleTable::default()),
                 tls_manager: Mutex::new(TLSManager::default()),
-                thread_maternity: SpinLock::new(Vec::new()),
                 capabilities
             }
         );
@@ -504,30 +521,17 @@ impl ProcessStruct {
     /// - `MemoryExhausted`
     ///    - Failed to allocate stack or thread TLS.
     pub fn start(this: &Arc<Self>, _main_thread_priority: u32, stack_size: usize) -> Result<(), UserspaceError> {
+
+        // Lock state mutex.
+        let mut statelock = this.state.lock();
+
         // ResourceLimit + 1 thread => 0x10801
         // Check imageSize + mainThreadStackSize + stackSize > memoryUsageCapacity => 0xD001 MemoryExhaustion
 
-        // Ensure we haven't already been started. Prevent running this method
-        // twice.
-        let oldstate = loop {
-            let oldstate = this.state.load(Ordering::Relaxed);
-            if oldstate != ProcessState::Created && oldstate != ProcessState::CreatedAttached {
-                return Err(UserspaceError::ProcessAlreadyStarted);
-            }
-
-            // Set new state early. Normally done after mapping memory and
-            // creating the first thread, among other things. Shouldn't matter
-            // for our purposes.
-            let newstate = match oldstate {
-                ProcessState::Created => ProcessState::Started,
-                ProcessState::CreatedAttached => ProcessState::StartedAttached,
-                _ => unreachable!()
-            };
-            let res = this.state.compare_exchange(oldstate, newstate, Ordering::SeqCst, Ordering::SeqCst);
-            if res.is_ok() {
-                break oldstate;
-            }
-        };
+        let oldstate = statelock.state;
+        if oldstate != ProcessState::Created && oldstate != ProcessState::CreatedAttached {
+            return Err(UserspaceError::ProcessAlreadyStarted);
+        }
 
         // ResourceLimit reserve align_up(stackSize, PAGE_SIZE) memory
         // Allocate stack within new map region.
@@ -546,22 +550,20 @@ impl ProcessStruct {
         this.phandles.lock().add_handle(Arc::new(Handle::Thread(first_thread.clone())));
         // SetEntryArguments - done in ThreadStruct::start for us.
 
-        // Normally, state is set here. We do it a bit earlier to make our
-        // atomic easier to manage.
+        // Set to new state.
+        statelock.set_state(match oldstate {
+            ProcessState::Created => ProcessState::Started,
+            ProcessState::CreatedAttached => ProcessState::StartedAttached,
+            _ => unreachable!()
+        });
 
         if let Err(err) = ThreadStruct::start(first_thread) {
-            // Start failed, go back to Created state. there is at worse
-            // the process will have been set to the "exited" state by
-            // svcTerminate before it had a chance to run. Allowing it to be
-            // restarted in that case isn't a huge deal.
+            // Start failed, go back to Created state. We don't undo the
+            // allocation of the stack. Nintendo doesn't either.
             //
-            // We don't undo the allocation of the stack. Nintendo doesn't
-            // either.
-            //
-            // An annoying side-effect of using atomics here: The temporary
-            // "Started" state is observable. Oh well.
+            // Nintendo signals when re-entering created state. Weird.
+            statelock.set_state(oldstate);
 
-            this.state.store(oldstate, Ordering::SeqCst);
             return Err(err.into());
         }
         Ok(())
@@ -604,14 +606,18 @@ impl ProcessStruct {
                 pmemory: Mutex::new(pmemory),
                 threads: SpinLockIRQ::new(Vec::new()),
                 phandles: SpinLockIRQ::new(HandleTable::default()),
-                state: Atomic::new(ProcessState::Started),
-                thread_maternity: SpinLock::new(Vec::new()),
+                state: Mutex::new(ProcessStateData {
+                    signaled: false,
+                    state: ProcessState::Started,
+                    waiting_threads: Vec::new(),
+                    thread_maternity: Vec::new(),
+                }),
                 tls_manager: Mutex::new(TLSManager::default()),
                 capabilities: ProcessCapabilities::default(),
         }
     }
 
-    /// Kills a process by killing all of its threads.
+    /// Kills the current process by killing all of its threads.
     ///
     /// When a thread is about to return to userspace, it checks if its state is Killed.
     /// In this case it unschedules itself instead, and its ThreadStruct is dropped.
@@ -620,14 +626,47 @@ impl ProcessStruct {
     ///
     /// We also mark the process struct as killed to prevent race condition with
     /// another thread that would want to spawn a thread after we killed all ours.
-    pub fn kill_process(this: Arc<Self>) {
-        // mark the process as killed
-        // Set exiting and exited.
-        this.state.store(ProcessState::Exited, Ordering::SeqCst);
+    pub fn kill_current_process() {
+        let this = scheduler::get_current_process();
+        let mut statelock = this.state.lock();
+
+        // Enter critical section.
+        if ![ProcessState::Started, ProcessState::StartedAttached, ProcessState::DebugSuspended]
+            .contains(&statelock.state)
+        {
+            // Leave critical section.
+            // In nintendo's code, the flow here is a bit weird. It kills the
+            // current thread. I find this a bit weird. If we call
+            // kill_current_process while not started, then something is clearly
+            // wrong in the kernel. So we'll panic instead.
+            panic!("Invalid state! Attempted to kill the current process while it wasn't started.");
+        }
+
+        // Normally, has the following flow:
+        // statelock.state = ProcessState::Exiting;
+        // Leave critical section.
+        // drop(statelock);
+        // KProcess::MaskThreads0x70Until(curThread)
+        // Destroy handle table.
+        // KMailBox::SendMail(0, KProcess::KMail)
+        // KThread::Exit(curThread)
+
+        // The SendMail will cause a kernel thread to wake up and
+        // (eventually) finalize the process, moving it to the exited
+        // state. Its flow is:
+        // KProcess::MaskThreads0x70Until(0)
+        // KProcess::SignalExitToDebugExited()
+        // KProcess::SignalExit()
+
+        // We're going to make things a **lot** simpler. We're just
+        // going to immediately set ourselves as exiting, kill our
+        // threads, and set ourselves as exited.
+        statelock.state = ProcessState::Exiting;
 
         // kill our baby threads. Those threads have never run, we don't even bother
         // scheduling them so the can free their resources, just drop the hole maternity.
-        this.thread_maternity.lock().clear();
+        statelock.thread_maternity.clear();
+        drop(statelock);
 
         // kill all other regular threads
         for weak_thread in this.threads.lock().iter() {
@@ -635,7 +674,8 @@ impl ProcessStruct {
                 ThreadStruct::exit(t);
             }
         }
-        drop(this);
+
+        this.state.lock().state = ProcessState::Exited;
     }
 
 }
@@ -705,7 +745,7 @@ impl ThreadStruct {
             Some(arg) => (arg, 0),
             None => {
                 debug_assert!(belonging_process.threads.lock().is_empty() &&
-                              belonging_process.thread_maternity.lock().is_empty(), "Argument shouldn't be None");
+                              belonging_process.state.lock().thread_maternity.is_empty(), "Argument shouldn't be None");
                 let handle = belonging_process.phandles.lock().add_handle(Arc::new(Handle::Thread(Arc::downgrade(&t))));
 
                 (0, handle as usize)
@@ -723,18 +763,18 @@ impl ThreadStruct {
         let ret = Arc::downgrade(&t);
 
         // add it to the process' list of threads, and to the maternity, simultaneously
-        let mut maternity = belonging_process.thread_maternity.lock();
-        let mut threads_vec = belonging_process.threads.lock();
-        if belonging_process.state.load(Ordering::SeqCst) == ProcessState::Exited {
+        let mut statelock = belonging_process.state.lock();
+        if statelock.state == ProcessState::Exited {
             // process was killed while we were waiting for the lock.
             // do not add the process to the vec, cancel the thread creation.
             drop(t);
             return Err(KernelError::ProcessKilled { backtrace: Backtrace::new() })
         }
+        let mut threads_vec = belonging_process.threads.lock();
         // push a weak in the threads_vec
         threads_vec.push(Arc::downgrade(&t));
         // and put the only strong in the maternity
-        maternity.push(t);
+        statelock.thread_maternity.push(t);
 
         Ok(ret)
     }
@@ -820,12 +860,13 @@ impl ThreadStruct {
             KernelError::ThreadAlreadyStarted { backtrace: Backtrace::new() }
         )?;
         // remove it from the maternity
-        let mut maternity = thread.process.thread_maternity.lock();
-        if thread.process.state.load(Ordering::SeqCst) == ProcessState::Exited {
+        let mut statelock = thread.process.state.lock();
+        if statelock.state == ProcessState::Exited {
             // process was killed while we were waiting for the lock.
             // do not start process to the vec, cancel the thread start.
             return Err(KernelError::ProcessKilled { backtrace: Backtrace::new() })
         }
+        let maternity = &mut statelock.thread_maternity;
         let cradle = maternity.iter().position(|baby| Arc::ptr_eq(baby, &thread));
         match cradle {
             None => {

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -26,8 +26,8 @@ pub use self::capabilities::ProcessCapabilities;
 use crate::paging::{InactiveHierarchy, InactiveHierarchyTrait, PAGE_SIZE, MappingAccessRights};
 use self::thread_local_storage::TLSManager;
 use crate::i386::interrupt_service_routines::UserspaceHardwareContext;
-use sunrise_libkern::process::ProcInfo;
-use sunrise_libkern::{ProcessState, MemoryType};
+use sunrise_libkern::process::{ProcessState, ProcInfo};
+use sunrise_libkern::MemoryType;
 
 /// Data related to the (user-visible) state the current process is in. The
 /// maternity is stored here to ensure there is no race condition between
@@ -567,6 +567,14 @@ impl ProcessStruct {
             return Err(err.into());
         }
         Ok(())
+    }
+
+    /// Gets the state of this process.
+    pub fn state(&self) -> ProcessState {
+        // Note: In nintendo, this code is *always* protected by a critical
+        // section on the g_sched object. We don't have that, so instead we go
+        // through a lock surrounding the ProcessStruct.
+        self.state.lock().state
     }
 
     /// Creates the very first process at boot.

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -412,12 +412,29 @@ impl HandleTable {
     }
 
     /// Gets the Kernel Handle associated with the given userspace handle number.
+    ///
+    /// # Errors
+    ///
+    /// - `InvalidHandle`
+    ///    - The provided handle does not exist in the handle table.
     pub fn get_handle(&self, handle: u32) -> Result<Arc<Handle>, UserspaceError> {
         match handle {
             0xFFFF8000 => Ok(Arc::new(Handle::Thread(Arc::downgrade(&scheduler::get_current_thread())))),
             0xFFFF8001 => Ok(Arc::new(Handle::Process(scheduler::get_current_process()))),
             handle => self.table.get(&handle).cloned().ok_or(UserspaceError::InvalidHandle)
         }
+    }
+
+    /// Gets the Kernel Handle associated with the given userspace handle number.
+    ///
+    /// Does not interpret 0xFFFF8000 and 0xFFFF8001.
+    ///
+    /// # Errors
+    ///
+    /// - `InvalidHandle`
+    ///    - The provided handle does not exist in the handle table.
+    pub fn get_handle_no_alias(&self, handle: u32) -> Result<Arc<Handle>, UserspaceError> {
+        self.table.get(&handle).cloned().ok_or(UserspaceError::InvalidHandle)
     }
 
     /// Deletes the mapping from the given userspace handle number. Returns the

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -530,7 +530,7 @@ impl ProcessStruct {
 
         let oldstate = statelock.state;
         if oldstate != ProcessState::Created && oldstate != ProcessState::CreatedAttached {
-            return Err(UserspaceError::ProcessAlreadyStarted);
+            return Err(UserspaceError::InvalidState);
         }
 
         // ResourceLimit reserve align_up(stackSize, PAGE_SIZE) memory
@@ -871,7 +871,7 @@ impl ThreadStruct {
         match cradle {
             None => {
                 // the thread was not found in the maternity, meaning it had already started.
-                Err(KernelError::ThreadAlreadyStarted { backtrace: Backtrace::new() })
+                Err(KernelError::InvalidState { backtrace: Backtrace::new() })
             },
             Some(pos) => {
                 // remove it from maternity, and put it in the schedule queue

--- a/kernel/src/syscalls.rs
+++ b/kernel/src/syscalls.rs
@@ -463,15 +463,19 @@ pub fn signal_event(handle: u32) -> Result<(), UserspaceError> {
 ///
 /// Takes either a [crate::event::ReadableEvent] or a
 /// [crate::event::WritableEvent].
+///
+/// # Errors
+///
+/// - `InvalidState`
+///   - The event wasn't signaled.
 pub fn clear_event(handle: u32) -> Result<(), UserspaceError> {
     let proc = scheduler::get_current_process();
     let handle = proc.phandles.lock().get_handle(handle)?;
     match &*handle {
-        Handle::ReadableEvent(event) => event.clear_signal(),
-        Handle::WritableEvent(event) => event.clear_signal(),
+        Handle::ReadableEvent(event) => event.clear_signal().map_err(|err| err.into()),
+        Handle::WritableEvent(event) => event.clear_signal().map_err(|err| err.into()),
         _ => Err(UserspaceError::InvalidHandle)?
     }
-    Ok(())
 }
 
 /// Create a new Port pair. Those ports are linked to each-other: The server will

--- a/kernel/src/syscalls.rs
+++ b/kernel/src/syscalls.rs
@@ -1124,3 +1124,26 @@ pub fn start_process(hnd: u32, main_thread_prio: u32, default_cpuid: u32, main_t
     ProcessStruct::start(&target_proc, main_thread_prio, main_thread_stacksz)?;
     Ok(())
 }
+
+/// Extract information from a process.
+///
+/// Info Type        | Description
+/// -----------------|--------------------------
+/// ProcessState = 0 | The state the current process is in. Returns an instance
+///                  | of [sunrise_libkern::process::ProcessState].
+///
+/// # Errors
+///
+/// - `InvalidHandle`
+///   - The passed handle is invalid or not a process.
+/// - `InvalidEnum`
+///   - The passed info_type is unknown.
+pub fn get_process_info(hnd: u32, info_type: u32) -> Result<usize, UserspaceError> {
+    let info_type = ProcessInfoType(info_type);
+    let target_proc = scheduler::get_current_process().phandles.lock().get_handle(hnd)?.as_process()?;
+
+    match info_type {
+        ProcessInfoType::ProcessState => Ok(target_proc.state().0 as usize),
+        _ => Err(UserspaceError::InvalidEnum)
+    }
+}

--- a/kernel/src/syscalls.rs
+++ b/kernel/src/syscalls.rs
@@ -1173,3 +1173,20 @@ pub fn reset_signal(hnd: u32) -> Result<(), UserspaceError> {
         _ => Err(UserspaceError::InvalidHandle)
     }
 }
+
+/// Gets the PID of the given Process handle. Alias handles (0xFFFF8000 and
+/// 0xFFFF8001) are not allowed here. PIDs are global, unique identifiers for a
+/// given process. PIDs are never reused, and can be passed over IPC safely (the
+/// kernel ensures the correct pid is passed when a process does a request),
+/// making them the best way for sysmodule to identify a calling process.
+///
+/// # Errors
+///
+/// - `InvalidHandle`
+///   - The given handle is invalid or not a process.
+pub fn get_process_id(hnd: u32) -> Result<usize, UserspaceError> {
+    let process = scheduler::get_current_process().phandles.lock()
+        .get_handle_no_alias(hnd)?.as_process()?;
+
+    Ok(process.pid)
+}

--- a/kernel/src/syscalls.rs
+++ b/kernel/src/syscalls.rs
@@ -303,7 +303,7 @@ pub fn create_thread(ip: usize, arg: usize, sp: usize, _priority: u32, _processo
 /// # Error
 ///
 /// * `InvalidHandle` if the handle is not a thread_handle,
-/// * `ProcessAlreadyStarted` if the thread has already started,
+/// * `InvalidState` if the thread has already started,
 #[allow(clippy::unit_arg)]
 pub fn start_thread(thread_handle: u32) -> Result<(), UserspaceError> {
     let cur_proc = get_current_process();

--- a/kernel/src/syscalls.rs
+++ b/kernel/src/syscalls.rs
@@ -248,7 +248,7 @@ pub fn output_debug_string(msg: UserSpacePtr<[u8]>, level: usize, target: UserSp
 
 /// Kills our own process.
 pub fn exit_process() -> Result<(), UserspaceError> {
-    ProcessStruct::kill_process(get_current_process());
+    ProcessStruct::kill_current_process();
     Ok(())
 }
 

--- a/libkern/src/error.rs
+++ b/libkern/src/error.rs
@@ -61,8 +61,9 @@ enum_with_val! {
         /// The remote part of the session was closed.
         PortRemoteDead = 123,
         // UnhandledInterrupt = 124,
-        /// Attempted to start a process that was already started.
-        ProcessAlreadyStarted = 125,
+        /// Attempted to do an operation that's invalid in the handle's current
+        /// state.
+        InvalidState = 125,
         /// Attempted to use an unknown value, reserved for future use.
         ReservedValue = 126,
         // InvalidHardwareBreakpoint = 127,
@@ -116,7 +117,7 @@ impl fmt::Display for KernelError {
             KernelError::ExceedingMaximum => write!(f, "Argument exceeded maximum possible value."),
             KernelError::NoSuchEntry => write!(f, "The entry does not exist."),
             KernelError::PortRemoteDead => write!(f, "Remote handle closed. Usually happens when an IPC got sent in the wrong format."),
-            KernelError::ProcessAlreadyStarted => write!(f, "Process already started."),
+            KernelError::InvalidState => write!(f, "Handle is in invalid state for this operation."),
             KernelError(err) => write!(f, "Unknown error: {}", err)
         }
     }

--- a/libkern/src/lib.rs
+++ b/libkern/src/lib.rs
@@ -32,6 +32,32 @@ use core::mem::size_of;
 
 pub mod process;
 
+/// The state the
+enum_with_val! {
+    #[derive(Default, Clone, Copy, PartialEq, Eq)]
+    pub struct ProcessState(u8) {
+        /// Process is freshly created with svcCreateProcess and has not yet been
+        /// started.
+        Created = 0,
+        /// Process has been attached with a debugger before it was started.
+        CreatedAttached = 1,
+        /// Process has been started.
+        Started = 2,
+        /// Process has crashed.
+        ///
+        /// Processes will not enter this state unless they were created with EnableDebug.
+        Crashed = 3,
+        /// Process is started and has a debugger attached.
+        StartedAttached = 4,
+        /// Process is currently exiting.
+        Exiting = 5,
+        /// Process is stopped.
+        Exited = 6,
+        /// Process has been suspended.
+        DebugSuspended = 7
+    }
+}
+
 bitflags! {
     /// Represents the current state of a memory region: why is it allocated, and
     /// what operations are allowed.

--- a/libkern/src/lib.rs
+++ b/libkern/src/lib.rs
@@ -32,32 +32,6 @@ use core::mem::size_of;
 
 pub mod process;
 
-/// The state the
-enum_with_val! {
-    #[derive(Default, Clone, Copy, PartialEq, Eq)]
-    pub struct ProcessState(u8) {
-        /// Process is freshly created with svcCreateProcess and has not yet been
-        /// started.
-        Created = 0,
-        /// Process has been attached with a debugger before it was started.
-        CreatedAttached = 1,
-        /// Process has been started.
-        Started = 2,
-        /// Process has crashed.
-        ///
-        /// Processes will not enter this state unless they were created with EnableDebug.
-        Crashed = 3,
-        /// Process is started and has a debugger attached.
-        StartedAttached = 4,
-        /// Process is currently exiting.
-        Exiting = 5,
-        /// Process is stopped.
-        Exited = 6,
-        /// Process has been suspended.
-        DebugSuspended = 7
-    }
-}
-
 bitflags! {
     /// Represents the current state of a memory region: why is it allocated, and
     /// what operations are allowed.

--- a/libkern/src/process.rs
+++ b/libkern/src/process.rs
@@ -212,3 +212,12 @@ enum_with_val! {
         DebugSuspended = 7
     }
 }
+
+enum_with_val! {
+    /// Kind of information to extract from a process wit `get_process_info`.
+    #[derive(Default, Clone, Copy, PartialEq, Eq)]
+    pub struct ProcessInfoType(pub u32) {
+        /// Get the state the process is currently in.
+        ProcessState = 0,
+    }
+}

--- a/libkern/src/process.rs
+++ b/libkern/src/process.rs
@@ -186,3 +186,29 @@ pub struct KipHeader {
 // Safety: KipHeader is a repr(C) struct with no padding, and all bit patterns
 // are valid.
 unsafe impl Plain for KipHeader {}
+
+enum_with_val! {
+    /// The state the process is currently in.
+    #[derive(Default, Clone, Copy, PartialEq, Eq)]
+    pub struct ProcessState(pub u8) {
+        /// Process is freshly created with svcCreateProcess and has not yet been
+        /// started.
+        Created = 0,
+        /// Process has been attached with a debugger before it was started.
+        CreatedAttached = 1,
+        /// Process has been started.
+        Started = 2,
+        /// Process has crashed.
+        ///
+        /// Processes will not enter this state unless they were created with EnableDebug.
+        Crashed = 3,
+        /// Process is started and has a debugger attached.
+        StartedAttached = 4,
+        /// Process is currently exiting.
+        Exiting = 5,
+        /// Process is stopped.
+        Exited = 6,
+        /// Process has been suspended.
+        DebugSuspended = 7
+    }
+}

--- a/libuser/src/error.rs
+++ b/libuser/src/error.rs
@@ -48,6 +48,8 @@ pub enum Error {
     Kernel(KernelError, Backtrace),
     /// Loader error.
     Loader(LoaderError, Backtrace),
+    /// Process Manager error.
+    Pm(PmError, Backtrace),
     /// Service Manager error.
     Sm(SmError, Backtrace),
     //Vi(ViError, Backtrace),
@@ -76,6 +78,7 @@ impl Error {
             Module::Kernel => Error::Kernel(KernelError::from_description(description), Backtrace::new()),
             Module::FileSystem => Error::FileSystem(FileSystemError(description), Backtrace::new()),
             Module::Loader => Error::Loader(LoaderError(description), Backtrace::new()),
+            Module::Pm => Error::Pm(PmError(description), Backtrace::new()),
             Module::Sm => Error::Sm(SmError(description), Backtrace::new()),
             //Module::Vi => Error::Vi(ViError(description), Backtrace::new()),
             Module::Libuser => Error::Libuser(LibuserError(description), Backtrace::new()),
@@ -94,6 +97,7 @@ impl Error {
             Error::Kernel(err, ..) => err.description() << 9 | Module::Kernel.0,
             Error::FileSystem(err, ..) => err.0 << 9 | Module::FileSystem.0,
             Error::Loader(err, ..) => err.0 << 9 | Module::Loader.0,
+            Error::Pm(err, ..) => err.0 << 9 | Module::Pm.0,
             Error::Sm(err, ..) => err.0 << 9 | Module::Sm.0,
             //Error::Vi(err, ..) => err.0 << 9 | Module::Vi.0,
             Error::Libuser(err, ..) => err.0 << 9 | Module::Libuser.0,
@@ -102,6 +106,22 @@ impl Error {
             Error::Hid(err, ..) => err.0 << 9 | Module::Hid.0,
             Error::Unknown(err, ..) => err,
         }
+    }
+}
+
+enum_with_val! {
+    #[derive(PartialEq, Eq, Clone, Copy)]
+    struct Module(u32) {
+        Kernel = 1,
+        FileSystem = 2,
+        Loader = 9,
+        Pm = 15,
+        Sm = 21,
+        Vi = 114,
+        Time = 116,
+        Hid = 202,
+        Libuser = 415,
+        Ahci = 416,
     }
 }
 
@@ -187,21 +207,6 @@ enum_with_val! {
 impl From<FileSystemError> for Error {
     fn from(error: FileSystemError) -> Self {
         Error::FileSystem(error, Backtrace::new())
-    }
-}
-
-enum_with_val! {
-    #[derive(PartialEq, Eq, Clone, Copy)]
-    struct Module(u32) {
-        Kernel = 1,
-        FileSystem = 2,
-        Loader = 9,
-        Sm = 21,
-        Vi = 114,
-        Time = 116,
-        Hid = 202,
-        Libuser = 415,
-        Ahci = 416,
     }
 }
 
@@ -326,6 +331,21 @@ enum_with_val! {
 impl From<LoaderError> for Error {
     fn from(error: LoaderError) -> Self {
         Error::Loader(error, Backtrace::new())
+    }
+}
+
+enum_with_val! {
+    /// PM Errors.
+    #[derive(PartialEq, Eq, Clone, Copy)]
+    pub struct PmError(u32) {
+        /// Pid not found
+        PidNotFound = 1,
+    }
+}
+
+impl From<PmError> for Error {
+    fn from(error: PmError) -> Self {
+        Error::Pm(error, Backtrace::new())
     }
 }
 

--- a/libuser/src/error.rs
+++ b/libuser/src/error.rs
@@ -316,6 +316,8 @@ enum_with_val! {
         InvalidKacs = 4,
         /// Invalid path read.
         InvalidPath = 6,
+        /// Tried to launch a title that does not exist.
+        ProgramNotFound = 8,
         /// The ELF is corrupted.
         InvalidElf = 9,
     }

--- a/libuser/src/lib.rs
+++ b/libuser/src/lib.rs
@@ -60,6 +60,8 @@ pub mod time {}
 pub mod fs {}
 #[gen_ipc(path = "../../ipcdefs/keyboard.id", prefix = "sunrise_libuser")]
 pub mod keyboard {}
+#[gen_ipc(path = "../../ipcdefs/loader.id", prefix = "sunrise_libuser")]
+pub mod ldr {}
 #[gen_ipc(path = "../../ipcdefs/example.id", prefix = "sunrise_libuser")]
 pub mod example {}
 

--- a/libuser/src/syscalls.rs
+++ b/libuser/src/syscalls.rs
@@ -713,3 +713,20 @@ pub(crate) fn reset_signal(event: HandleRef) -> Result<(), KernelError> {
         Ok(())
     }
 }
+
+/// Gets the PID of the given Process handle. Alias handles (0xFFFF8000 and
+/// 0xFFFF8001) are not allowed here. PIDs are global, unique identifiers for a
+/// given process. PIDs are never reused, and can be passed over IPC safely (the
+/// kernel ensures the correct pid is passed when a process does a request),
+/// making them the best way for sysmodule to identify a calling process.
+///
+/// # Errors
+///
+/// - `InvalidHandle`
+///   - The given handle is invalid or not a process.
+pub fn get_process_id(process_handle: &Process) -> Result<u64, KernelError> {
+    unsafe {
+        let (pid, ..) = syscall(nr::GetProcessInfo, (process_handle.0).0.get() as usize, 0, 0, 0, 0, 0)?;
+        Ok(pid as _)
+    }
+}

--- a/libuser/src/syscalls.rs
+++ b/libuser/src/syscalls.rs
@@ -208,6 +208,11 @@ pub fn signal_event(event: &WritableEvent) -> Result<(), KernelError> {
 /// [signal_event()] is called once again.
 ///
 /// Takes either a [ReadableEvent] or a [WritableEvent].
+///
+/// # Errors
+///
+/// - `InvalidState`
+///   - The event wasn't signaled.
 pub(crate) fn clear_event(event: HandleRef) -> Result<(), KernelError> {
     unsafe {
         syscall(nr::ClearEvent, event.inner.get() as _, 0, 0, 0, 0, 0)?;

--- a/libuser/src/syscalls.rs
+++ b/libuser/src/syscalls.rs
@@ -252,15 +252,19 @@ pub fn map_shared_memory(handle: &SharedMemory, addr: usize, size: usize, perm: 
 ///
 /// Unmaps a shared memory mapping at the given address.
 ///
+/// # Safety
+///
+/// This function unmaps the memory, invalidating any pointer to the given
+/// region. The user must take care that no pointers point to this region before
+/// calling this function.
+///
 /// # Errors:
 ///
 /// - addr must point to a mapping backed by the given handle
 /// - Size must be equal to the size of the backing shared memory handle.
-pub fn unmap_shared_memory(handle: &SharedMemory, addr: usize, size: usize) -> Result<(), KernelError> {
-    unsafe {
-        syscall(nr::UnmapSharedMemory, (handle.0).0.get() as _, addr, size, 0, 0, 0)?;
-        Ok(())
-    }
+pub unsafe fn unmap_shared_memory(handle: &SharedMemory, addr: usize, size: usize) -> Result<(), KernelError> {
+    syscall(nr::UnmapSharedMemory, (handle.0).0.get() as _, addr, size, 0, 0, 0)?;
+    Ok(())
 }
 
 // Not totally public because it's not safe to use directly
@@ -593,6 +597,12 @@ pub fn map_process_memory(dstaddr: usize, proc_handle: &Process, srcaddr: usize,
 ///
 /// It is possible to partially unmap a ProcessMemory.
 ///
+/// # Safety
+///
+/// This function unmaps the memory, invalidating any pointer to the given
+/// region. The user must take care that no pointers point to this region before
+/// calling this function.
+///
 /// # Errors
 ///
 /// - `InvalidAddress`
@@ -614,11 +624,9 @@ pub fn map_process_memory(dstaddr: usize, proc_handle: &Process, srcaddr: usize,
 /// - `InvalidHandle`
 ///    - The handle passed as an argument does not exist or is not a Process
 ///      handle.
-pub fn unmap_process_memory(dstaddr: usize, proc_handle: &Process, srcaddr: usize, size: usize) -> Result<(), KernelError> {
-    unsafe {
-        syscall(nr::UnmapProcessMemory, dstaddr, (proc_handle.0).0.get() as _, srcaddr, size, 0, 0)?;
-        Ok(())
-    }
+pub unsafe fn unmap_process_memory(dstaddr: usize, proc_handle: &Process, srcaddr: usize, size: usize) -> Result<(), KernelError> {
+    syscall(nr::UnmapProcessMemory, dstaddr, (proc_handle.0).0.get() as _, srcaddr, size, 0, 0)?;
+    Ok(())
 }
 
 /// Creates a new process with the given parameters.

--- a/libuser/src/syscalls.rs
+++ b/libuser/src/syscalls.rs
@@ -672,3 +672,23 @@ pub fn start_process(process_handle: &Process, main_thread_prio: u32, default_cp
         Ok(())
     }
 }
+
+/// Extract information from a process.
+///
+/// Info Type        | Description
+/// -----------------|--------------------------
+/// ProcessState = 0 | The state the current process is in. Returns an instance
+///                  | of [sunrise_libkern::process::ProcessState].
+///
+/// # Errors
+///
+/// - `InvalidHandle`
+///   - The passed handle is invalid or not a process.
+/// - `InvalidEnum`
+///   - The passed info_type is unknown.
+pub fn get_process_info(process_handle: &Process, ty: ProcessInfoType) -> Result<u32, KernelError> {
+    unsafe {
+        let (info, ..) = syscall(nr::GetProcessInfo, (process_handle.0).0.get() as usize, ty.0 as usize, 0, 0, 0, 0)?;
+        Ok(info as _)
+    }
+}

--- a/libuser/src/syscalls.rs
+++ b/libuser/src/syscalls.rs
@@ -692,3 +692,24 @@ pub fn get_process_info(process_handle: &Process, ty: ProcessInfoType) -> Result
         Ok(info as _)
     }
 }
+
+/// Clear the "signaled" state of a readable event or process. After calling
+/// this on a signaled event, [wait_synchronization()] on this handle will wait
+/// until the handle is signaled again.
+///
+/// Takes either a [ReadableEvent] or a [Process].
+///
+/// Note that once a Process enters the Exited state, it is permanently signaled
+/// and cannot be reset. Calling ResetSignal will return an InvalidState error.
+///
+/// # Errors
+///
+/// - `InvalidState`
+///   - The event wasn't signaled.
+///   - The process was in Exited state.
+pub(crate) fn reset_signal(event: HandleRef) -> Result<(), KernelError> {
+    unsafe {
+        syscall(nr::ResetSignal, event.inner.get() as _, 0, 0, 0, 0, 0)?;
+        Ok(())
+    }
+}

--- a/libuser/src/types.rs
+++ b/libuser/src/types.rs
@@ -546,11 +546,15 @@ impl MappedSharedMemory {
     }
 
     /// Gets a raw pointer to the underlying shared memory.
+    ///
+    /// The pointer is valid until the MappedSharedMemory instance gets dropped.
     pub fn as_ptr(&self) -> *const u8 {
         self.addr as *const u8
     }
 
     /// Gets a mutable raw pointer to the underlying shared memory.
+    ///
+    /// The pointer is valid until the MappedSharedMemory instance gets dropped.
     pub fn as_mut_ptr(&self) -> *mut u8 {
         self.addr as *mut u8
     }
@@ -569,7 +573,11 @@ impl MappedSharedMemory {
 
 impl Drop for MappedSharedMemory {
     fn drop(&mut self) {
-        let _ = syscalls::unmap_shared_memory(&self.handle, self.addr, self.size);
+        unsafe {
+            // Safety: If this is dropped, then all references given out to the
+            // data pointed to by addr should have been dropped as well.
+            let _ = syscalls::unmap_shared_memory(&self.handle, self.addr, self.size);
+        }
     }
 }
 

--- a/libuser/src/types.rs
+++ b/libuser/src/types.rs
@@ -7,6 +7,7 @@ use core::marker::PhantomData;
 use crate::syscalls;
 use core::num::NonZeroU32;
 use sunrise_libkern::MemoryPermissions;
+use sunrise_libkern::process::{ProcessState, ProcessInfoType};
 use crate::error::{Error, KernelError};
 use crate::ipc::{Message, MessageTy};
 use crate::futures::WorkQueue;
@@ -466,6 +467,15 @@ impl Process {
     pub fn start(&self, main_thread_prio: u32, default_cpuid: u32, main_thread_stack_sz: u32) -> Result<(), Error> {
         syscalls::start_process(self, main_thread_prio, default_cpuid, main_thread_stack_sz)
             .map_err(|v| v.into())
+    }
+
+    /// Get the state the given process is currently in.
+    ///
+    /// Shouldn't ever return an error, unless the user is doing weird things
+    /// with handles.
+    pub fn state(&self) -> Result<ProcessState, Error> {
+        let info = syscalls::get_process_info(self, ProcessInfoType::ProcessState)?;
+        Ok(ProcessState(info as u8))
     }
 }
 

--- a/libuser/src/types.rs
+++ b/libuser/src/types.rs
@@ -506,6 +506,19 @@ impl Process {
         syscalls::reset_signal(self.0.as_ref())?;
         Ok(())
     }
+
+    /// Gets the [Pid] of this Process.
+    ///
+    /// Will return an `InvalidHandle` error if called on `Process::current()`.
+    ///
+    /// # Errors
+    ///
+    /// - `InvalidHandle`
+    ///   - Called in `Process::current()`.
+    pub fn pid(&self) -> Result<Pid, Error> {
+        let pid = syscalls::get_process_id(self)?;
+        Ok(Pid(pid))
+    }
 }
 
 /// A handle to memory that may be mapped in multiple processes at the same time.

--- a/libuser/src/types.rs
+++ b/libuser/src/types.rs
@@ -100,7 +100,7 @@ impl<'a> HandleRef<'a> {
     /// Panics if used from outside the context of a Future spawned on a libuser
     /// future executor. Please make sure you only call this function from a
     /// future spawned on a WaitableManager.
-    fn wait_async<'b>(self, queue: WorkQueue<'b>)-> impl core::future::Future<Output = Result<(), Error>> + Unpin +'b {
+    pub fn wait_async<'b>(self, queue: WorkQueue<'b>)-> impl core::future::Future<Output = Result<(), Error>> + Unpin +'b {
         #[allow(missing_docs, clippy::missing_docs_in_private_items)]
         struct MyFuture<'a> {
             queue: crate::futures::WorkQueue<'a>,
@@ -638,5 +638,5 @@ impl Drop for MappedSharedMemory {
 /// Each process in Horizon is given a unique, non-reusable PID. It may be used
 /// to associate capabilities or resources to a particular process. For instance,
 /// sm might associate a process' service access permissions to its pid.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Pid(pub u64);

--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -10,3 +10,8 @@ sunrise-libkern = { path = "../libkern" }
 sunrise-libutils = { path = "../libutils" }
 log = "0.4"
 xmas-elf = "0.7.0"
+futures-preview = { version = "0.3.0-alpha.16", default-features = false, features = ["nightly", "alloc"] }
+
+[dependencies.lazy_static]
+features = ["spin_no_std"]
+version = "1.3.0"

--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -11,6 +11,8 @@ sunrise-libutils = { path = "../libutils" }
 log = "0.4"
 xmas-elf = "0.7.0"
 futures-preview = { version = "0.3.0-alpha.16", default-features = false, features = ["nightly", "alloc"] }
+spin = "0.5.2"
+core = { package = "core-futures-tls", version = "0.1.1" }
 
 [dependencies.lazy_static]
 features = ["spin_no_std"]

--- a/loader/src/elf_loader.rs
+++ b/loader/src/elf_loader.rs
@@ -79,7 +79,7 @@ pub fn get_kacs<'a>(elf: &'a ElfFile<'_>) -> Option<&'a [u8]> {
 /// - `KernelError`
 ///   - A syscall failed while trying to map the remote process memory or set
 ///     the mappings' permissions.
-pub fn load_builtin(process: &Process, elf: &ElfFile<'_>, base: usize) -> Result<(), Error> {
+pub fn load_file(process: &Process, elf: &ElfFile<'_>, base: usize) -> Result<(), Error> {
     // load all segments into the page_table we had above
     for ph in elf.program_iter().filter(|ph|
         if let Ok(Load) = ph.get_type() { true } else { false })

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -197,6 +197,7 @@ lazy_static! {
     };
 }
 
+/// Struct implementing the ldr:shel service.
 #[derive(Debug, Default)]
 struct LoaderIface;
 

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -131,7 +131,7 @@ fn boot(fs: &IFileSystemProxy, titlename: &str, args: &[u8]) -> Result<(), Error
     }, &kacs)?;
 
     debug!("Loading ELF");
-    elf_loader::load_builtin(&process, &elf, aslr_base)?;
+    elf_loader::load_file(&process, &elf, aslr_base)?;
 
     debug!("Handling args");
     let addr = find_free_address(args_size, 0x1000)?;

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -255,14 +255,17 @@ fn main() {
             },
             name => {
                 // Try to run it as an external binary.
-                match loader.launch_title(name.as_bytes(), line.as_bytes()) {
+                let res = loader.launch_title(name.as_bytes(), line.as_bytes())
+                    .and_then(|pid| loader.wait(pid));
+
+                match res {
                     Err(Error::Loader(LoaderError::ProgramNotFound, _)) => {
                         let _ = writeln!(&mut terminal, "Unknown command");
                     },
                     Err(err) => {
                         let _ = writeln!(&mut terminal, "Error: {:?}", err);
                     },
-                    Ok(_) => ()
+                    Ok(_exitstatus) => ()
                 }
             }
         }


### PR DESCRIPTION
- Loader now has an interface to spawn new processes at runtime.
- We can also add Loader to wait until a process is killed.