### PR TITLE
Kernel: Use SeqCst for ARE_CPU_LOCALS_INIT

### DIFF
--- a/kernel/src/cpu_locals.rs
+++ b/kernel/src/cpu_locals.rs
@@ -196,7 +196,7 @@ pub fn init_cpu_locals(cpu_count: usize) {
     });
 
     // yes, they are 😌
-    ARE_CPU_LOCALS_INITIALIZED_YET.store(true, Ordering::Relaxed);
+    ARE_CPU_LOCALS_INITIALIZED_YET.store(true, Ordering::SeqCst);
 }
 
 /// The `round` function, as defined in section 3.0:

--- a/kernel/src/scheduler.rs
+++ b/kernel/src/scheduler.rs
@@ -36,7 +36,7 @@ static CURRENT_THREAD: RefCell<Option<Arc<ThreadStruct>>> = RefCell::new(None);
 pub fn try_get_current_thread() -> Option<Arc<ThreadStruct>> {
     // if cpu_locals haven't been initialized, accessing gs:0 will triple fault,
     // so don't even remotely try to access it.
-    if !ARE_CPU_LOCALS_INITIALIZED_YET.load(Ordering::Relaxed) {
+    if !ARE_CPU_LOCALS_INITIALIZED_YET.load(Ordering::SeqCst) {
         None
     } else {
         CURRENT_THREAD.borrow().clone()


### PR DESCRIPTION
Relaxed is 100% broken in SMP context here.