### PR TITLE
Kernel: Make query_physical_memory work like HOS

### DIFF
--- a/ahci/src/hba.rs
+++ b/ahci/src/hba.rs
@@ -1140,7 +1140,8 @@ impl CmdTable {
         let mut temp_buffer_addr = buffer as usize;
         let mut index = 0;
         while length > 0 {
-            let (mut phys_addr, _, mut phys_len, phys_off) = query_physical_address(temp_buffer_addr)?;
+            let (mut phys_addr, base_addr, mut phys_len) = query_physical_address(temp_buffer_addr)?;
+            let phys_off = temp_buffer_addr as usize - base_addr;
             phys_addr += phys_off;
             phys_len -= phys_off;
             // divide into 4M regions.

--- a/kernel/src/i386/interrupt_service_routines.rs
+++ b/kernel/src/i386/interrupt_service_routines.rs
@@ -936,7 +936,7 @@ fn syscall_interrupt_dispatcher(_exception_name: &'static str, hwcontext: &mut U
         (true, nr::CreateEvent) => hwcontext.apply2(create_event()),
         (true, nr::CreateSharedMemory) => hwcontext.apply1(create_shared_memory(x0 as _, x1 as _, x2 as _)),
         (true, nr::CreateInterruptEvent) => hwcontext.apply1(create_interrupt_event(x0, x1 as u32)),
-        (true, nr::QueryPhysicalAddress) => hwcontext.apply4(query_physical_address(x0 as _)),
+        (true, nr::QueryPhysicalAddress) => hwcontext.apply3(query_physical_address(x0 as _)),
         (true, nr::CreatePort) => hwcontext.apply2(create_port(x0 as _, x1 != 0, UserSpacePtr(x2 as _))),
         (true, nr::ManageNamedPort) => hwcontext.apply1(manage_named_port(UserSpacePtr(x0 as _), x1 as _)),
         (true, nr::ConnectToPort) => hwcontext.apply1(connect_to_port(x0 as _)),

--- a/libuser/src/mem.rs
+++ b/libuser/src/mem.rs
@@ -94,7 +94,9 @@ pub fn map_mmio<T>(physical_address: usize) -> Result<*mut T, KernelError> {
 ///
 /// * query_physical_address failed.
 pub fn virt_to_phys<T>(virtual_address: *const T) -> usize {
-    let (phys_region_start, _, _, phys_region_offset) = syscalls::query_physical_address(virtual_address as usize)
+    let (phys_region_start, base_addr, _) = syscalls::query_physical_address(virtual_address as usize)
         .expect("syscall query_physical_memory failed");
-    phys_region_start + phys_region_offset
+
+    let offset = virtual_address as usize - base_addr;
+    phys_region_start + offset
 }

--- a/libuser/src/syscalls.rs
+++ b/libuser/src/syscalls.rs
@@ -431,19 +431,16 @@ pub fn create_interrupt_event(irqnum: usize, flag: u32) -> Result<ReadableEvent,
 /// # Return
 ///
 /// 0. The start address of the physical region.
-/// 1. 0x00000000 (On Horizon it contains the KernelSpace virtual address of this mapping,
-///    but I don't see any use for it).
-/// 2. The length of the physical region.
-// sunrise extension
-/// 3. The offset in the region of the given virtual address.
+/// 1. The start address of the virtual region.
+/// 2. The length of the region.
 ///
 /// # Error
 ///
 /// - InvalidAddress: This address does not map physical memory.
-pub fn query_physical_address(virtual_address: usize) -> Result<(usize, usize, usize, usize), KernelError> {
+pub fn query_physical_address(virtual_address: usize) -> Result<(usize, usize, usize), KernelError> {
     unsafe {
-        let (phys_addr, kernel_addr, phys_len, offset, ..) = syscall(nr::QueryPhysicalAddress, virtual_address, 0, 0, 0, 0, 0)?;
-        Ok((phys_addr, kernel_addr, phys_len, offset))
+        let (phys_addr, base_addr, phys_len, ..) = syscall(nr::QueryPhysicalAddress, virtual_address, 0, 0, 0, 0, 0)?;
+        Ok((phys_addr, base_addr, phys_len))
     }
 }
 


### PR DESCRIPTION
Closes #203 

Our previous query_physical_address was super broken. The phys_offset in particular could, in certain conditions, return some absolutely absurd values.

While investigating this bug, I took some time to figure out how the HOS kernel really implements it, and found out that the documentation on switchbrew was actually super wrong, or at least misleading. So I fixed the implementation to remove the sunriseos extension phys_offset. Instead, now it implements it just like Nintendo, which means it returns three values:

- Physical Address of the base of the mapping
- Virtual Address of the base of the mapping
- Size of the mapping.

Where the mapping is the closest contiguous range of physical address below the given address.