### PR TITLE
Libstd stdout goes to terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,6 +2095,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sunrise-twili"
+version = "0.1.0"
+dependencies = [
+ "core-futures-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sunrise-libuser 0.1.0",
+]
+
+[[package]]
 name = "sunrise-vi"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2109,6 +2109,7 @@ dependencies = [
 name = "sunrise-vi"
 version = "0.1.0"
 dependencies = [
+ "bit_field 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-futures-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "font-rs 0.1.3 (git+https://github.com/SunriseOS/font-rs)",
  "futures-preview 0.3.0-alpha.16 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,8 @@
 [workspace]
-members = ["kernel", "bootstrap", "shell", "time", "libuser", "wall-clock", "sm", "vi", "ahci", "fs", "libutils", "libkern", "swipc-gen", "swipc-parser", "docs", "libtimezone", "disk-initializer", "loader", "keyboard", "std_hello_world", "coreutils"]
+members = ["kernel", "bootstrap", "shell", "time", "libuser", "wall-clock",
+    "sm", "vi", "ahci", "fs", "libutils", "libkern", "swipc-gen",
+    "swipc-parser", "docs", "libtimezone", "disk-initializer", "loader",
+    "keyboard", "std_hello_world", "twili", "coreutils"]
 
 [patch.crates-io.libc]
 git = "https://github.com/sunriseos/libc.git"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -161,9 +161,19 @@ dependencies = ["install-xargo"]
 command = "xargo"
 args = ["build", "--target=i386-unknown-sunrise-user", "--package=uutils", "-Z", "package-features", "--features=sunrise", "--no-default-features", "@@split(COMPILER_FLAGS, )"]
 
+[tasks.userspace-nostd]
+internal = true
+command = "xargo"
+args = ["build", "--target=i386-unknown-sunrise-user", "@@split(COMPILER_FLAGS, )",
+    "-p", "sunrise-shell", "-p", "sunrise-wall-clock", "-p", "sunrise-sm",
+    "-p", "sunrise-vi", "-p", "sunrise-ahci", "-p", "sunrise-time",
+    "-p", "sunrise-fs", "-p", "sunrise-loader", "-p", "sunrise-keyboard",
+    "-p", "sunrise-twili"
+]
+
 [tasks.userspace]
 description = "Compiles userspace apps"
-dependencies = ["shell", "wall-clock", "sm", "vi", "ahci", "time", "fs", "loader", "keyboard", "twili", "std_hello_world", "uutils"]
+dependencies = ["userspace-nostd", "std_hello_world", "uutils"]
 
 [tasks.iso]
 description = "Creates a bootable ISO containing the kernel and grub."

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -143,6 +143,12 @@ dependencies = ["install-xargo"]
 command = "xargo"
 args = ["build", "--target=i386-unknown-sunrise-user", "--package=sunrise-keyboard", "@@split(COMPILER_FLAGS, )"]
 
+[tasks.twili]
+description = "Compiles sunrise-twili"
+dependencies = ["install-xargo"]
+command = "xargo"
+args = ["build", "--target=i386-unknown-sunrise-user", "--package=sunrise-twili", "@@split(COMPILER_FLAGS, )"]
+
 [tasks.std_hello_world]
 description = "Compiles std_hello_world"
 dependencies = ["install-xargo"]
@@ -157,7 +163,7 @@ args = ["build", "--target=i386-unknown-sunrise-user", "--package=uutils", "-Z",
 
 [tasks.userspace]
 description = "Compiles userspace apps"
-dependencies = ["shell", "wall-clock", "sm", "vi", "ahci", "time", "fs", "loader", "keyboard", "std_hello_world", "uutils"]
+dependencies = ["shell", "wall-clock", "sm", "vi", "ahci", "time", "fs", "loader", "keyboard", "twili", "std_hello_world", "uutils"]
 
 [tasks.iso]
 description = "Creates a bootable ISO containing the kernel and grub."
@@ -192,7 +198,10 @@ touch external/filesystem/disk_template/bin/wall-clock/flags/boot.flag
 
 mkdir -p external/filesystem/disk_template/bin/std_hello_world/flags
 cp target/i386-unknown-sunrise-user/$PROFILE_NAME/std_hello_world    external/filesystem/disk_template/bin/std_hello_world/main
-touch external/filesystem/disk_template/bin/std_hello_world/flags/boot.flag
+
+mkdir -p external/filesystem/disk_template/bin/twili/flags
+cp target/i386-unknown-sunrise-user/$PROFILE_NAME/sunrise-twili external/filesystem/disk_template/bin/twili/main
+touch external/filesystem/disk_template/bin/twili/flags/boot.flag
 
 mkdir -p external/filesystem/disk_template/bin/uutils
 cp target/i386-unknown-sunrise-user/$PROFILE_NAME/uutils     external/filesystem/disk_template/bin/uutils/main
@@ -321,7 +330,7 @@ args = ["-c", "kernel/src/main.rs", "bootstrap/src/main.rs",
 	"sm/src/main.rs", "vi/src/main.rs", "ahci/src/main.rs",
 	"libutils/src/lib.rs", "libkern/src/lib.rs", "swipc-gen/src/lib.rs",
 	"swipc-parser/src/lib.rs", "time/src/main.rs", "libtimezone/src/lib.rs",
-	"loader/src/main.rs", "keyboard/src/main.rs"
+	"loader/src/main.rs", "keyboard/src/main.rs", "twili/src/main.rs"
 ]
 
 [tasks.clippy-sunrise-kernel-target]

--- a/ipcdefs/loader.id
+++ b/ipcdefs/loader.id
@@ -2,9 +2,12 @@
 #
 # Responsible for creating, loading, starting and waiting on processes.
 interface sunrise_libuser::ldr::ILoaderInterface is ldr:shel {
-    # Create, load and start the process `title_name` with the given args.
-    # Returns the process' pid.
-    [0] launch_title(array<u8, 9> title_name, array<u8, 9> args) -> u64 pid;
+    # Create and load the process `title_name` with the given args.
+    # Returns the process' pid. The process will not be started yet, use
+    # `launch_title` to start it.
+    [0] create_title(array<u8, 9> title_name, array<u8, 9> args) -> u64 pid;
+    # Starts a process created with create_title.
+    [2] launch_title(u64 pid);
     # Wait for the process with the given pid, returning the exit status.
     [1] wait(u64 pid) -> u32 exit_status;
 }

--- a/ipcdefs/twili.id
+++ b/ipcdefs/twili.id
@@ -11,13 +11,16 @@ interface sunrise_libuser::twili::ITwiliService is twili {
         object<sunrise_libuser::twili::IPipe> stdin,
         object<sunrise_libuser::twili::IPipe> stdout,
         object<sunrise_libuser::twili::IPipe> stderr);
+
+    # Creates a pipe whose read side gets sent to the write side.
+    [1] create_pipe() -> object<sunrise_libuser::twili::IPipe>;
 }
 
 # The Twili Manager is responsible for registering a process' pipes. The PM
 # should connect to this service and register pipes before starting a process.
 interface sunrise_libuser::twili::ITwiliManagerService is twili:m {
     # Registers the pipe of a remote process.
-    [0] register_pipes(pid,
+    [0] register_pipes(u64 pid,
         object<sunrise_libuser::twili::IPipe> stdin,
         object<sunrise_libuser::twili::IPipe> stdout,
         object<sunrise_libuser::twili::IPipe> stderr);

--- a/keyboard/src/ps2.rs
+++ b/keyboard/src/ps2.rs
@@ -331,6 +331,18 @@ impl PS2 {
                     Released => { self.is_right_shift.store(false, SeqCst); }
                 }
             }
+            HidKeyboardScancode::LeftCtrl => {
+                match state {
+                    Pressed  => { self.is_left_ctrl.store(true,  SeqCst); }
+                    Released => { self.is_left_ctrl.store(false, SeqCst); }
+                }
+            }
+            HidKeyboardScancode::RightCtrl => {
+                match state {
+                    Pressed  => { self.is_right_ctrl.store(true,  SeqCst); }
+                    Released => { self.is_right_ctrl.store(false, SeqCst); }
+                }
+            }
             _ => { debug!("Keyboard: {} {:?}", match state { Pressed => "pressed ", Released => "released" }, key); }
         }
     }
@@ -342,7 +354,7 @@ impl PS2 {
             true  => char::from(key.upper_case)
         }
     }
-    
+
     /// Get a bitfield representing the modifiers of this keyboard
     fn encode_modifiers(&self, state: State) -> u8 {
         let caps_locked = self.is_capslocked.load(SeqCst) as u8;

--- a/libuser/src/syscalls.rs
+++ b/libuser/src/syscalls.rs
@@ -724,7 +724,7 @@ pub(crate) fn reset_signal(event: HandleRef) -> Result<(), KernelError> {
 ///   - The given handle is invalid or not a process.
 pub fn get_process_id(process_handle: &Process) -> Result<u64, KernelError> {
     unsafe {
-        let (pid, ..) = syscall(nr::GetProcessInfo, (process_handle.0).0.get() as usize, 0, 0, 0, 0, 0)?;
+        let (pid, ..) = syscall(nr::GetProcessId, (process_handle.0).0.get() as usize, 0, 0, 0, 0, 0)?;
         Ok(pid as _)
     }
 }

--- a/libuser/src/terminal.rs
+++ b/libuser/src/terminal.rs
@@ -96,6 +96,11 @@ impl Terminal {
         Ok(())
     }
 
+    /// Clone this terminal's pipe.
+    pub fn clone_pipe(&self) -> Result<crate::twili::IPipeProxy, Error> {
+        self.pipe.clone_current_object()
+    }
+
     /// Read a line of text. Note that it might return without reading an entire
     /// line if the buffer is not big enough. The user should check if a \n is
     /// present in data.

--- a/rust/src/libstd/Cargo.toml
+++ b/rust/src/libstd/Cargo.toml
@@ -60,6 +60,8 @@ fortanix-sgx-abi = { version = "0.3.2", features = ['rustc-dep-of-std'] }
 # Need #SunriseOS/SunriseOS#402 to actually build
 sunrise-libuser = { git = "https://github.com/sunriseos/sunriseos.git", default-features = false, features = ['rustc-dep-of-std'] }
 lazy_static = { version = "1.3", features = ['spin_no_std'] }
+log = "0.4"
+spin = "0.5"
 
 [build-dependencies]
 cc = "1.0"

--- a/rust/src/libstd/sys/sunrise/mod.rs
+++ b/rust/src/libstd/sys/sunrise/mod.rs
@@ -37,6 +37,11 @@ pub mod thread_local;
 
 #[cfg(not(test))]
 pub fn init() {
+    use core::intrinsics::abort;
+    if let Err(err) = stdio::init() {
+        log::error!("Error initializing stdio! {:?}", err);
+        unsafe { abort(); }
+    }
     fs::init();
 }
 

--- a/rust/src/libstd/sys/sunrise/process.rs
+++ b/rust/src/libstd/sys/sunrise/process.rs
@@ -102,7 +102,8 @@ impl Command {
         };
 
         // TODO(Sunrise): Remap error codes
-        let pid = interface.launch_title(self.program.as_bytes(), command_line.as_bytes()).unwrap();
+        let pid = interface.create_title(self.program.as_bytes(), command_line.as_bytes()).unwrap();
+        interface.launch_title(pid).unwrap();
 
         let child = Process {
             pid,

--- a/rust/src/libstd/sys/sunrise/stdio.rs
+++ b/rust/src/libstd/sys/sunrise/stdio.rs
@@ -1,8 +1,21 @@
 use crate::io;
 
+use sunrise_libuser::error::Error;
+use sunrise_libuser::twili::{ITwiliServiceProxy, IPipeProxy};
+use spin::Once;
+
 pub struct Stdin;
 pub struct Stdout;
 pub struct Stderr;
+
+pub static PIPES: Once<(IPipeProxy, IPipeProxy, IPipeProxy)> =
+    Once::new();
+
+pub fn init() -> Result<(), Error> {
+    let pipes = ITwiliServiceProxy::new()?.open_pipes()?;
+    PIPES.call_once(|| pipes);
+    Ok(())
+}
 
 impl Stdin {
     pub fn new() -> io::Result<Stdin> {
@@ -11,8 +24,10 @@ impl Stdin {
 }
 
 impl io::Read for Stdin {
-    fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
-        panic!("not supported on sunrise yet")
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        PIPES.r#try()
+            .ok_or(io::Error::from(io::ErrorKind::NotFound))
+            .and_then(|v| Ok(v.0.read(buf)? as usize))
     }
 }
 
@@ -24,14 +39,9 @@ impl Stdout {
 
 impl io::Write for Stdout {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        // TODO(Sunrise): Bufferize
-        use sunrise_libuser::syscalls::output_debug_string;
-
-        let buf = unsafe { core::str::from_utf8_unchecked(buf) };
-
-        let _ = output_debug_string(buf, 50, "stdout");
-
-        Ok(buf.len())
+        PIPES.r#try()
+            .ok_or(io::Error::from(io::ErrorKind::NotFound))
+            .and_then(|v| { v.1.write(buf)?; Ok(buf.len()) })
     }
 
     fn flush(&mut self) -> io::Result<()> {
@@ -47,7 +57,6 @@ impl Stderr {
 
 impl io::Write for Stderr {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        // TODO(Sunrise): Bufferize
         use sunrise_libuser::syscalls::output_debug_string;
 
         let buf = unsafe { core::str::from_utf8_unchecked(buf) };

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -168,7 +168,7 @@ pub fn get_next_line(logger: &mut Terminal) -> String {
 fn main() {
     let mut terminal = Terminal::new(WindowSize::FontLines(-1, false)).unwrap();
     let mut keyboard = Keyboard::new().unwrap();
-    let mut twili = ITwiliManagerServiceProxy::new().unwrap();
+    let twili = ITwiliManagerServiceProxy::new().unwrap();
     let loader = ILoaderInterfaceProxy::raw_new().unwrap();
 
     let fs_proxy = IFileSystemServiceProxy::raw_new().unwrap();

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -269,8 +269,11 @@ fn main() {
             },
             name => {
                 // Try to run it as an external binary.
-                let res = loader.launch_title(name.as_bytes(), line.as_bytes())
-                    .and_then(|pid| loader.wait(pid));
+                let res = (|| {
+                    let pid = loader.create_title(name.as_bytes(), line.as_bytes())?;
+                    loader.launch_title(pid)?;
+                    loader.wait(pid)
+                })();
 
                 match res {
                     Err(Error::Loader(LoaderError::ProgramNotFound, _)) => {

--- a/swipc-gen/src/gen_rust_code.rs
+++ b/swipc-gen/src/gen_rust_code.rs
@@ -890,6 +890,12 @@ pub fn generate_proxy(ifacename: &str, interface: &Interface) -> String {
     }
 
     writeln!(s, "impl {} {{", struct_name).unwrap();
+    writeln!(s, "    /// Clones the current object, returning a new handle.").unwrap();
+    writeln!(s, "    /// The returned handle has its own IPC buffer - it may be used concurrently with the original.").unwrap();
+    writeln!(s, "    pub fn clone_current_object(&self) -> Result<Self, Error> {{").unwrap();
+    writeln!(s, "        Ok({}::from(self.0.try_clone()?))", struct_name).unwrap();
+    writeln!(s, "    }}").unwrap();
+
     for cmd in &interface.funcs {
         match format_cmd(&cmd) {
             Ok(out) => write!(s, "{}", out).unwrap(),

--- a/twili/Cargo.toml
+++ b/twili/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sunrise-twili"
+version = "0.1.0"
+authors = ["roblabla <unfiltered@roblab.la>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sunrise-libuser = { path = "../libuser" }
+spin = "0.5"
+log = "0.4"
+lazy_static = { version = "1.3.0", features = ["spin_no_std"] }
+core = { package = "core-futures-tls", version = "0.1" }

--- a/twili/src/main.rs
+++ b/twili/src/main.rs
@@ -1,0 +1,135 @@
+#![feature(async_await)]
+#![no_std]
+
+extern crate alloc;
+
+use core::cmp::min;
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::collections::VecDeque;
+use alloc::sync::Arc;
+
+use spin::Mutex;
+use lazy_static::lazy_static;
+
+use sunrise_libuser::{kip_header, capabilities};
+use sunrise_libuser::error::{Error, PmError};
+use sunrise_libuser::ipc;
+use sunrise_libuser::ipc::server::{port_handler, new_session_wrapper};
+use sunrise_libuser::futures::{WaitableManager, WorkQueue};
+use sunrise_libuser::futures_rs::future::FutureObj;
+use sunrise_libuser::syscalls;
+use sunrise_libuser::twili::{ITwiliManagerService, ITwiliService, IPipeProxy, IPipeAsync};
+use sunrise_libuser::types::{WritableEvent, ReadableEvent, Pid};
+
+#[derive(Debug, Default, Clone)]
+struct TwiliManIface;
+impl ITwiliManagerService for TwiliManIface {
+    fn register_pipes(
+        &mut self,
+        _manager: WorkQueue<'static>,
+        pid: u64,
+        stdin: IPipeProxy,
+        stdout: IPipeProxy,
+        stderr: IPipeProxy) -> Result<(), Error>
+    {
+        log::info!("Registering pipes for {}", pid);
+        PIPES.lock().insert(pid, (stdin, stdout, stderr));
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct TwiliIface;
+impl ITwiliService for TwiliIface {
+    fn open_pipes(&mut self, _manager: WorkQueue<'static>, pid: Pid) -> Result<(IPipeProxy, IPipeProxy, IPipeProxy), Error> {
+        log::info!("Opening pipes for {}", pid.0);
+        PIPES.lock().remove(&pid.0)
+            .ok_or(PmError::PidNotFound.into())
+    }
+
+    fn create_pipe(&mut self, manager: WorkQueue<'static>) -> Result<IPipeProxy, Error> {
+        let pipe = DumbPipe(Arc::new(Mutex::new(VecDeque::new())));
+        let (server, client) = syscalls::create_session(false, 0)?;
+        let wrapper = new_session_wrapper(manager.clone(), server, pipe, DumbPipe::dispatch);
+        manager.spawn(FutureObj::new(Box::new(wrapper)));
+        Ok(IPipeProxy::from(client))
+    }
+}
+
+lazy_static! {
+    static ref PIPES: Mutex<BTreeMap<u64, (IPipeProxy, IPipeProxy, IPipeProxy)>> =
+        Mutex::new(BTreeMap::new());
+    static ref DATA_EVENT: (WritableEvent, ReadableEvent) = {
+        sunrise_libuser::syscalls::create_event().unwrap()
+    };
+}
+
+#[derive(Debug, Clone)]
+struct DumbPipe(Arc<Mutex<VecDeque<u8>>>);
+impl IPipeAsync for DumbPipe {
+    fn read<'a>(&'a mut self, work_queue: WorkQueue<'static>, buf: &'a mut [u8]) -> FutureObj<'a, Result<u64, Error>> {
+        FutureObj::new(Box::new(async move {
+            DATA_EVENT.1.wait_async_cb(work_queue.clone(), || {
+                self.0.lock().get(0).map(|_| ())
+            }).await;
+            let mut locked = self.0.lock();
+            let count = min(buf.len(), locked.len());
+            for (idx, item) in locked.drain(..count).enumerate() {
+                buf[idx] = item;
+            }
+            Ok(count as u64)
+        }))
+    }
+
+    fn write<'a>(&'a mut self, _manager: WorkQueue<'static>, buf: &'a [u8]) -> FutureObj<'a, Result<(), Error>> {
+        FutureObj::new(Box::new(async move {
+            self.0.lock().extend(buf);
+            DATA_EVENT.0.signal().unwrap();
+            Ok(())
+        }))
+    }
+}
+
+fn main() {
+    let mut man = WaitableManager::new();
+
+    let handler = port_handler(man.work_queue(), "twili", TwiliIface::dispatch).unwrap();
+    man.work_queue().spawn(FutureObj::new(Box::new(handler)));
+    let handler = port_handler(man.work_queue(), "twili:m", TwiliManIface::dispatch).unwrap();
+    man.work_queue().spawn(FutureObj::new(Box::new(handler)));
+
+    man.run();
+}
+
+kip_header!(HEADER = sunrise_libuser::caps::KipHeader {
+    magic: *b"KIP1",
+    name: *b"twili\0\0\0\0\0\0\0",
+    title_id: 0x0200000000006480,
+    process_category: sunrise_libuser::caps::ProcessCategory::KernelBuiltin,
+    main_thread_priority: 0,
+    default_cpu_core: 0,
+    flags: 0,
+    reserved: 0,
+    stack_page_count: 16,
+});
+
+capabilities!(CAPABILITIES = Capabilities {
+    svcs: [
+        sunrise_libuser::syscalls::nr::SleepThread,
+        sunrise_libuser::syscalls::nr::ExitProcess,
+        sunrise_libuser::syscalls::nr::CloseHandle,
+        sunrise_libuser::syscalls::nr::WaitSynchronization,
+        sunrise_libuser::syscalls::nr::OutputDebugString,
+        sunrise_libuser::syscalls::nr::SetThreadArea,
+
+        sunrise_libuser::syscalls::nr::SetHeapSize,
+        sunrise_libuser::syscalls::nr::QueryMemory,
+        sunrise_libuser::syscalls::nr::ConnectToNamedPort,
+        sunrise_libuser::syscalls::nr::SendSyncRequestWithUserBuffer,
+
+        sunrise_libuser::syscalls::nr::ReplyAndReceiveWithUserBuffer,
+        sunrise_libuser::syscalls::nr::AcceptSession,
+    ],
+    raw_caps: [sunrise_libuser::caps::ioport(0x60), sunrise_libuser::caps::ioport(0x64), sunrise_libuser::caps::irq_pair(1, 0x3FF)]
+});

--- a/vi/Cargo.toml
+++ b/vi/Cargo.toml
@@ -13,6 +13,7 @@ spin = "0.5"
 futures-preview = { version = "0.3.0-alpha.16", default-features = false, features = ["nightly", "alloc"] }
 font-rs = { git = "https://github.com/SunriseOS/font-rs", default-features = false }
 log = "0.4"
+bit_field = "0.10"
 core = { package = "core-futures-tls", version = "0.1" }
 
 [dependencies.hashbrown]


### PR DESCRIPTION
We now implement a twili service that's responsible for giving a process its stdin/stdout/stderr. Stderr is ignored for now, as it's used for panics, and having panics go to svcOutputDebugString is too useful.