### PR TITLE
Keyboard refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,6 +1979,7 @@ dependencies = [
 name = "sunrise-keyboard"
 version = "0.1.0"
 dependencies = [
+ "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-futures-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/keyboard/Cargo.toml
+++ b/keyboard/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 generic-array = "0.13.0"
+arrayvec = {version = "0.4", default-features = false}
 spin = "0.5"
 log = "0.4.6"
 sunrise-libuser = { path = "../libuser" }


### PR DESCRIPTION
My goal here was to try to read from the port in as few places as possible (as well as trying to handle weird edge cases) in preparation for sending commands / receiving responses. In the process, though, I may have made `KeyEvent::read_key_event` an even more messy function than before...