### PR TITLE
 Panic if SpinLock locked in interrupt context

### DIFF
--- a/kernel/src/i386/interrupt_service_routines.rs
+++ b/kernel/src/i386/interrupt_service_routines.rs
@@ -52,6 +52,7 @@ use sunrise_libkern::{nr, SYSCALL_NAMES};
 /// Contains the number of interrupts we are currently inside.
 ///
 /// When this is 0, we are not inside an interrupt context.
+#[thread_local]
 pub static INSIDE_INTERRUPT_COUNT: AtomicU8 = AtomicU8::new(0);
 
 /// Checks if our thread was killed, in which case unschedule ourselves.

--- a/kernel/src/process.rs
+++ b/kernel/src/process.rs
@@ -172,7 +172,7 @@ pub struct ThreadStruct {
     /// Userspace hardware context of this thread.
     ///
     /// Registers are backed up every time we enter the kernel via a syscall/exception, for debug purposes.
-    pub userspace_hwcontext: SpinLock<UserspaceHardwareContext>,
+    pub userspace_hwcontext: SpinLockIRQ<UserspaceHardwareContext>,
 
     /// Thread state event
     ///
@@ -796,7 +796,7 @@ impl ThreadStruct {
                 process: Arc::clone(belonging_process),
                 tls_region: tls,
                 tls_elf: SpinLock::new(VirtualAddress(0x00000000)),
-                userspace_hwcontext: SpinLock::new(UserspaceHardwareContext::default()),
+                userspace_hwcontext: SpinLockIRQ::new(UserspaceHardwareContext::default()),
                 state_event: ThreadStateEvent {
                     waiting_threads: SpinLock::new(Vec::new())
                 },
@@ -894,7 +894,7 @@ impl ThreadStruct {
                 process: Arc::clone(&process),
                 tls_region: tls,
                 tls_elf: SpinLock::new(VirtualAddress(0x00000000)),
-                userspace_hwcontext: SpinLock::new(UserspaceHardwareContext::default()),
+                userspace_hwcontext: SpinLockIRQ::new(UserspaceHardwareContext::default()),
                 state_event: ThreadStateEvent {
                     waiting_threads: SpinLock::new(Vec::new())
                 },
@@ -984,4 +984,3 @@ impl Drop for ThreadStruct {
         info!("💀 Dropped a thread : {}", self.process.name)
     }
 }
-

--- a/kernel/src/sync/mod.rs
+++ b/kernel/src/sync/mod.rs
@@ -96,6 +96,14 @@ pub use self::spin_lock::{SpinLock, SpinLockGuard};
 pub mod mutex;
 pub use self::mutex::{Mutex, MutexGuard};
 
+/// Boolean to [spin_lock_irq::permanently_disable_interrupts].
+///
+/// If this bool is set, all attempts to enable interrupts through a SpinLockIRQ
+/// are ignored, leaving the system in an unrecoverable state.
+///
+/// This is used by kernel panic handlers.
+static INTERRUPT_DISARM: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+
 /// Abstraction around various kind of locks.
 ///
 /// Some functions need to take a Lock and/or a LockGuard as argument, but don't

--- a/kernel/src/sync/mod.rs
+++ b/kernel/src/sync/mod.rs
@@ -32,7 +32,7 @@
 //! try to access it in regular context. This would be useful on multi-core systems to arbitrate
 //! access to a resource when two IRQs are run concurrently.
 //! But we highly discourage it, as we see no use case for a resource that would be accessed *only*
-//! in interrupt context.
+//! in interrupt context. So, our implementation panics when locked in interrupt context.
 //!
 //! # SpinLockIRQ
 //!
@@ -84,12 +84,14 @@
 //! [Mutex]: crate::sync::mutex::Mutex
 
 // export spin::Mutex as less ambiguous "SpinLock".
-pub use spin::{Mutex as SpinLock, MutexGuard as SpinLockGuard,
-               RwLock as SpinRwLock, RwLockReadGuard as SpinRwLockReadGuard, RwLockWriteGuard as SpinRwLockWriteGuard,
+pub use spin::{RwLock as SpinRwLock, RwLockReadGuard as SpinRwLockReadGuard, RwLockWriteGuard as SpinRwLockWriteGuard,
                Once };
 
 pub mod spin_lock_irq;
 pub use self::spin_lock_irq::{SpinLockIRQ, SpinLockIRQGuard};
+
+pub mod spin_lock;
+pub use self::spin_lock::{SpinLock, SpinLockGuard};
 
 pub mod mutex;
 pub use self::mutex::{Mutex, MutexGuard};

--- a/kernel/src/sync/spin_lock.rs
+++ b/kernel/src/sync/spin_lock.rs
@@ -121,7 +121,10 @@ impl<T: ?Sized> SpinLock<T> {
     /// ```
     pub fn lock(&self) -> SpinLockGuard<T> {
         use core::sync::atomic::Ordering;
-        if crate::i386::interrupt_service_routines::INSIDE_INTERRUPT_COUNT.load(Ordering::SeqCst) != 0 {
+        use crate::cpu_locals::ARE_CPU_LOCALS_INITIALIZED_YET;
+        use crate::i386::interrupt_service_routines::INSIDE_INTERRUPT_COUNT;
+        use super::INTERRUPT_DISARM;
+        if !INTERRUPT_DISARM.load(Ordering::SeqCst) && ARE_CPU_LOCALS_INITIALIZED_YET.load(Ordering::SeqCst) && INSIDE_INTERRUPT_COUNT.load(Ordering::SeqCst) != 0 {
             panic!("\
                 You have attempted to lock a spinlock in interrupt context. \
                 This is most likely a design flaw. \

--- a/kernel/src/sync/spin_lock.rs
+++ b/kernel/src/sync/spin_lock.rs
@@ -1,0 +1,156 @@
+//! Lock that panics when used in a IRQ context
+//!
+//! See the [sync] module documentation.
+//!
+//! [sync]: crate::sync
+
+use core::fmt;
+
+pub use spin::MutexGuard as SpinLockGuard;
+
+/// This type provides mutual exclusion based on spinning.
+/// It will panic if used in the context of an interrupt.
+///
+/// # Description
+///
+/// The behaviour of these locks is similar to `std::sync::Mutex`. they
+/// differ on the following:
+///
+/// - The lock will not be poisoned in case of failure;
+///
+/// # Simple examples
+///
+/// ```
+/// use crate::sync::SpinLock;
+/// let spin_lock = SpinLock::new(0);
+///
+/// // Modify the data
+/// {
+///     let mut data = spin_lock.lock();
+///     *data = 2;
+/// }
+///
+/// // Read the data
+/// let answer =
+/// {
+///     let data = spin_lock.lock();
+///     *data
+/// };
+///
+/// assert_eq!(answer, 2);
+/// ```
+///
+/// # Thread-safety example
+///
+/// ```
+/// use crate::sync::SpinLock;
+/// use std::sync::{Arc, Barrier};
+///
+/// let numthreads = 1000;
+/// let spin_lock = Arc::new(SpinLock::new(0));
+///
+/// // We use a barrier to ensure the readout happens after all writing
+/// let barrier = Arc::new(Barrier::new(numthreads + 1));
+///
+/// for _ in (0..numthreads)
+/// {
+///     let my_barrier = barrier.clone();
+///     let my_lock = spin_lock.clone();
+///     std::thread::spawn(move||
+///     {
+///         let mut guard = my_lock.lock();
+///         *guard += 1;
+///
+///         // Release the lock to prevent a deadlock
+///         drop(guard);
+///         my_barrier.wait();
+///     });
+/// }
+///
+/// barrier.wait();
+///
+/// let answer = { *spin_lock.lock() };
+/// assert_eq!(answer, numthreads);
+/// ```
+#[repr(transparent)]
+pub struct SpinLock<T: ?Sized>(spin::Mutex<T>);
+
+impl<T> SpinLock<T> {
+    /// Creates a new spinlock wrapping the supplied data.
+    ///
+    /// May be used statically:
+    ///
+    /// ```
+    /// use crate::sync::SpinLock;
+    ///
+    /// static SPINLOCK: SpinLock<()> = SpinLock::new(());
+    ///
+    /// fn demo() {
+    ///     let lock = SPINLOCK.lock();
+    ///     // do something with lock
+    ///     drop(lock);
+    /// }
+    /// ```
+    pub const fn new(data: T) -> SpinLock<T> {
+        SpinLock(spin::Mutex::new(data))
+    }
+
+    /// Consumes this spinlock, returning the underlying data.
+    pub fn into_inner(self) -> T {
+        self.0.into_inner()
+    }
+}
+
+impl<T: ?Sized> SpinLock<T> {
+    /// Locks the spinlock and returns a guard.
+    ///
+    /// The returned value may be dereferenced for data access
+    /// and the lock will be dropped when the guard falls out of scope.
+    ///
+    /// Panics if called in an interrupt context.
+    ///
+    /// ```
+    /// let mylock = crate::sync::SpinLock::new(0);
+    /// {
+    ///     let mut data = mylock.lock();
+    ///     // The lock is now locked and the data can be accessed
+    ///     *data += 1;
+    ///     // The lock is implicitly dropped
+    /// }
+    ///
+    /// ```
+    pub fn lock(&self) -> SpinLockGuard<T> {
+        use core::sync::atomic::Ordering;
+        assert_eq!(crate::i386::interrupt_service_routines::INSIDE_INTERRUPT_COUNT.load(Ordering::SeqCst), 0);
+        self.0.lock()
+    }
+
+    /// Force unlock the spinlock.
+    ///
+    /// This is *extremely* unsafe if the lock is not held by the current
+    /// thread. However, this can be useful in some instances for exposing the
+    /// lock to FFI that doesn't know how to deal with RAII.
+    ///
+    /// If the lock isn't held, this is a no-op.
+    pub unsafe fn force_unlock(&self) {
+        self.0.force_unlock()
+    }
+
+    /// Tries to lock the spinlock. If it is already locked, it will return None. Otherwise it returns
+    /// a guard within Some.
+    pub fn try_lock(&self) -> Option<SpinLockGuard<T>> {
+        self.0.try_lock()
+    }
+}
+
+impl<T: ?Sized + fmt::Debug> fmt::Debug for SpinLock<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T: ?Sized + Default> Default for SpinLock<T> {
+    fn default() -> SpinLock<T> {
+        Self::new(Default::default())
+    }
+}

--- a/kernel/src/sync/spin_lock_irq.rs
+++ b/kernel/src/sync/spin_lock_irq.rs
@@ -9,15 +9,8 @@ use spin::{Mutex as SpinLock, MutexGuard as SpinLockGuard};
 use core::fmt;
 use core::mem::ManuallyDrop;
 use core::ops::{Deref, DerefMut};
-use core::sync::atomic::{AtomicBool, Ordering};
-
-/// Boolean to [permanently_disable_interrupts].
-///
-/// If this bool is set, all attempts to enable interrupts through a SpinLockIRQ
-/// are ignored, leaving the system in an unrecoverable state.
-///
-/// This is used by kernel panic handlers.
-static INTERRUPT_DISARM: AtomicBool = AtomicBool::new(false);
+use core::sync::atomic::Ordering;
+use super::INTERRUPT_DISARM;
 
 /// Permanently disables the interrupts. Forever.
 ///

--- a/kernel/src/sync/spin_lock_irq.rs
+++ b/kernel/src/sync/spin_lock_irq.rs
@@ -5,7 +5,7 @@
 //! [sync]: crate::sync
 
 use crate::i386::instructions::interrupts;
-pub use spin::{Mutex as SpinLock, MutexGuard as SpinLockGuard};
+use spin::{Mutex as SpinLock, MutexGuard as SpinLockGuard};
 use core::fmt;
 use core::mem::ManuallyDrop;
 use core::ops::{Deref, DerefMut};

--- a/kernel/src/sync/spin_lock_irq.rs
+++ b/kernel/src/sync/spin_lock_irq.rs
@@ -5,7 +5,7 @@
 //! [sync]: crate::sync
 
 use crate::i386::instructions::interrupts;
-use super::{SpinLock, SpinLockGuard};
+pub use spin::{Mutex as SpinLock, MutexGuard as SpinLockGuard};
 use core::fmt;
 use core::mem::ManuallyDrop;
 use core::ops::{Deref, DerefMut};


### PR DESCRIPTION
Fixes #471.

This involves creating a newtype wrapper around spin::Mutex to check when locking if the number of interrupts being serviced is currently zero.