### PR TITLE
CI: Bitrot protection for dep installs.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,10 +68,10 @@ jobs:
         shell: bash
 
       - name: Install cargo-make
-        run: cargo install cargo-make
+        run: cargo install cargo-make --version 0.22.0 --locked
 
-      - name: Install xargo (from master branch)
-        run: cargo install --git https://github.com/japaric/xargo.git
+      - name: Install xargo
+        run: cargo install xargo --version 0.3.18 --locked
 
       - name: Build develop
         run: cargo make iso

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -75,7 +75,7 @@ install_crate = { crate_name = "mkisofs-rs", binary = "mkisofs-rs", test_arg = "
 
 [tasks.install-xargo]
 dependencies = ["install-rust-src"]
-install_crate = { crate_name = "xargo", binary = "xargo", test_arg = "--version", min_version = "0.3.16" }
+install_crate = { crate_name = "xargo", binary = "xargo", test_arg = "--version", min_version = "0.3.18" }
 
 [tasks.bootstrap]
 description = "Compiles the i386 bootstrap"

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -49,7 +49,7 @@ printed on stdout.
   - clippy
   - rust-src
 - cargo-make: `0.22.0`
-- xargo: `0.3.16 (21e4808)`
+- xargo: `0.3.18`
 - mkisofs-rs: `0.1.1`
 - qemu-system-i386: `4.0.50`
 - cargo-travis: `https://github.com/roblabla/cargo-travis` branch `doc-upload-target`


### PR DESCRIPTION
Ensure we build xargo and cargo-make in a reproducible way to prevent bitrot. We now specify a version and ask for a locked build. My understanding is that --locked will use the lockfile packaged by the crate, see https://github.com/rust-lang/cargo/issues/5654.