### PR TITLE
Lock binary dependencies

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -4,6 +4,7 @@ min_version = "0.31.0"
 default_to_workspace = false
 
 [env]
+CARGO_MAKE_CRATE_INSTALLATION_LOCKED = "true"
 RUST_TARGET_PATH = "${CARGO_MAKE_WORKING_DIRECTORY}"
 XARGO_RUST_SRC = "${CARGO_MAKE_WORKING_DIRECTORY}/rust/src"
 GDB_PORT = { script = ["echo ${GDB_PORT:-9090}"] }


### PR DESCRIPTION
Make sure binary dependencies are built with their dependencies locked, so we don't end up with problems if the dependencies don't support our nightly anymore.

Fixes #647 
Fixes #585 